### PR TITLE
fix(brt/gps): ajusta configurações, adiciona parâmetro faltante 😱

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -39,9 +39,9 @@ vars:
   polygon_garagem: "rj-smtr.br_rj_riodejaneiro_geo.garagens_polygon" # aux_registros_parada
   sppo_terminais: "rj-smtr.br_rj_riodejaneiro_transporte.terminais_onibus_coordenadas" # aux_registros_parada
   sppo_registros_staging: rj-smtr-staging.br_rj_riodejaneiro_onibus_gps_staging.registros
-  
+
   # Parametros de intersecção do ônibus com rota
-   ## Tamanho do buffer da rota
+  ## Tamanho do buffer da rota
   tamanho_buffer_metros: 500 # flag_trajeto_correto
   ## Intervalo máximo que um veículo pode ficar fora da rota para ser considerado
   ## dentro da rota. Afeta a flag flag_trajeto_correto_hist
@@ -57,6 +57,9 @@ vars:
 
   # Modal SPPO (ônibus)
   sppo_id_modal_smtr: ["'22'", "'23'", "'O'"]
+
+  # Modal BRT
+  brt_id_modal_smtr: ["'20'", "'B'"]
 
   ### SIGMOB ###
   data_inclusao_agency: "2021-08-03"
@@ -83,7 +86,6 @@ vars:
   stop_details_staging: "rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.stop_details"
   stops_staging: "rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.stops"
   trips_staging: "rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.trips"
-  
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_filtrada.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_filtrada.sql
@@ -1,3 +1,13 @@
+{{ 
+  config(
+      materialized='incremental',
+      partition_by={
+            "field":"data",
+            "data_type": "date",
+            "granularity":"day"
+      }
+  )
+}}
 /*
 - Descrição:
 Filtragem e tratamento básico de registros de gps.

--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_flag_trajeto_correto.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_flag_trajeto_correto.sql
@@ -64,7 +64,7 @@ WITH
     LEFT JOIN (
       SELECT * 
       FROM {{ ref('shapes_geom') }} 
-      WHERE id_modal_smtr in ({{ id_modal_smtr|join(', ') }})
+      WHERE id_modal_smtr in ({{ var('brt_id_modal_smtr')|join(', ') }})
       {% if not flags.FULL_REFRESH -%}
       AND data_versao between DATE({{var('date_range_start')}}) and DATE({{var('date_range_end')}})
       {% endif %}

--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_parada.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_parada.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    materialized='incremental'
+    materialized='ephemeral'
   )
 }}
 /*

--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_velocidade.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_velocidade.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized='incremental'
+        materialized='ephemeral'
     )
 }}
 /*

--- a/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
+++ b/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
@@ -134,3 +134,9 @@ ON
   r.id_veiculo = p.id_veiculo
   AND  r.timestamp_gps = p.timestamp_gps
   AND r.linha = p.linha
+{% if is_incremental() -%}
+  WHERE
+  data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
+  AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
+  AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
+{%- endif -%}


### PR DESCRIPTION
Descrição breve:
Ajuste simples das configurações de materialização das tabelas e adiciona parâmetro `brt_id_modal_smtr` que não estava declarado.