### PR TITLE
fix(gps): conserta modo incremental das tabelas `gps_[modo]` ⚒️

### DIFF
--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_flag_trajeto_correto.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_flag_trajeto_correto.sql
@@ -28,7 +28,7 @@ WITH
     {% if not flags.FULL_REFRESH -%}
     WHERE
     data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-    AND timestamp_gps > "{{var('date_range_start')}}" and "{{var('date_range_end')}}"
+    AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
     {%- endif %}
   ),
   intersec AS (
@@ -66,7 +66,7 @@ WITH
       FROM {{ ref('shapes_geom') }} 
       WHERE id_modal_smtr in ({{ var('brt_id_modal_smtr')|join(', ') }})
       {% if not flags.FULL_REFRESH -%}
-      AND data_versao between DATE({{var('date_range_start')}}) and DATE({{var('date_range_end')}})
+      AND data_versao between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
       {% endif %}
     ) s
     ON

--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_parada.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_parada.sql
@@ -48,7 +48,7 @@ WITH
       {% if not flags.FULL_REFRESH -%}
       WHERE
       data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-      AND timestamp_gps > "{{var('date_range_start')}}" and "{{var('date_range_end')}}"
+      AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
       {% endif %}
     ) r
     on 1=1

--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_velocidade.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_velocidade.sql
@@ -53,7 +53,7 @@ with
     {% if not flags.FULL_REFRESH -%}
     WHERE
     data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-    AND timestamp_gps > "{{var('date_range_start')}}" and "{{var('date_range_end')}}"
+    AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
     {% endif %}
     ),
     medias as (

--- a/models/br_rj_riodejaneiro_veiculos/gps_brt.sql
+++ b/models/br_rj_riodejaneiro_veiculos/gps_brt.sql
@@ -130,4 +130,10 @@ JOIN
 ON  
     r.id_veiculo = p.id_veiculo
     AND  r.timestamp_gps = p.timestamp_gps
-    AND r.servico = p.servico 
+    AND r.servico = p.servico
+{% if is_incremental() -%}
+  WHERE
+  date(r.timestamp_gps) between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
+  AND r.timestamp_gps > "{{var('date_range_start')}}" and r.timestamp_gps <="{{var('date_range_end')}}"
+  AND DATETIME_DIFF(r.timestamp_captura, r.timestamp_gps, MINUTE) BETWEEN 0 AND 1
+{%- endif -%}

--- a/models/br_rj_riodejaneiro_veiculos/gps_brt.sql
+++ b/models/br_rj_riodejaneiro_veiculos/gps_brt.sql
@@ -36,9 +36,9 @@ WITH
     FROM {{ ref('brt_aux_registros_filtrada') }}
     {% if is_incremental() -%}
     WHERE
-    data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-    AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-    AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
+      data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
+      AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
+      AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
     {%- endif -%}
     ),
     velocidades AS (

--- a/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
+++ b/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
@@ -136,7 +136,7 @@ ON
   AND r.linha = p.linha
 {% if is_incremental() -%}
   WHERE
-  data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-  AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-  AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
+  date(r.timestamp_gps) between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
+  AND r.timestamp_gps > "{{var('date_range_start')}}" and r.timestamp_gps <="{{var('date_range_end')}}"
+  AND DATETIME_DIFF(r.timestamp_captura, r.timestamp_gps, MINUTE) BETWEEN 0 AND 1
 {%- endif -%}

--- a/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
+++ b/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
@@ -33,13 +33,12 @@ WITH
       linha,
       latitude,
       longitude,
-
     FROM {{ ref('sppo_aux_registros_filtrada') }}
     {% if is_incremental() -%}
     WHERE
-    data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-    AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-    AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
+      data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
+      AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
+      AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
     {%- endif -%}
   ),
   velocidades AS (


### PR DESCRIPTION
Descrição breve: Corrige os erros de `date_range` das pipelines. Testado já em modo `incremental` com: 

```
dbt run --select +gps_sppo --exclude +data_versao_efetiva --vars "{'date_range_start': '2022-06-09T11:01:19', 'date_range_end': '2022-06-09T12:00:12', 'version': '807264220155c06ac2249cda9ac0a750062d758f'}"
```

TODO:

- [ ] Ver como obter os logs de erro do dbt => a pipeline roda no Prefect sem apresentar o erro
- [ ] Mudar `--select`/`--exclude` na pipeline do Prefect @Hellcassius 