### PR TITLE
fix(gps): remove filtros de seleção de serviço/linha

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -62,6 +62,9 @@ vars:
   brt_id_modal_smtr: ["'20'", "'B'"]
 
   ### SIGMOB ###
+  # data_versao fixada para operações que envolvem o uso do SIGMOB
+  versao_fixa_sigmob: '2022-06-10'
+
   data_inclusao_agency: "2021-08-03"
   data_inclusao_stop_times: "2021-08-03"
   data_inclusao_linhas: "2021-08-03"

--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_flag_trajeto_correto.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_flag_trajeto_correto.sql
@@ -55,26 +55,16 @@ WITH
       -- 3. Identificação de cadastro da linha no SIGMOB
       CASE WHEN s.linha_gtfs IS NULL THEN False ELSE True END AS flag_linha_existe_sigmob,
     -- 4. Join com data_versao_efetiva para definição de quais shapes serão considerados no cálculo das flags
-    FROM (
-      SELECT t1.*, t2.data_versao_efetiva_shapes as data_versao_efetiva
-      FROM registros t1
-      JOIN  {{ ref("data_versao_efetiva") }} t2
-      ON t1.data = t2.data
-    ) r
+    FROM registros r
     LEFT JOIN (
       SELECT * 
-      FROM {{ ref('shapes_geom') }} 
+      FROM `rj-smtr.br_rj_riodejaneiro_sigmob.shapes_geom`
       WHERE id_modal_smtr in ({{ var('brt_id_modal_smtr')|join(', ') }})
-      {% if not flags.FULL_REFRESH -%}
-      AND data_versao between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-      {% endif %}
+      AND data_versao = "{{var('versao_fixa_sigmob')}}"
     ) s
     ON
       r.linha = s.linha_gtfs
-    AND
-      r.data_versao_efetiva = s.data_versao
-  ),
-  flags as  (
+  )
     -- 5. Agregação com LOGICAL_OR para evitar duplicação de registros
     SELECT
       id_veiculo,
@@ -100,48 +90,4 @@ WITH
       data,
       data_versao,
       timestamp_gps
-  ),
-  counts as (
-  select 
-      id_veiculo,
-      timestamp_gps,
-      linha,
-      (case when flag_trajeto_correto is true then 3 else 0 end + 
-      case when flag_trajeto_correto_hist is true then 2 else 0 end + 
-      case when flag_linha_existe_sigmob is true then 1 else 0 end) most_true, 
-      count(linha) over (partition by id_veiculo, timestamp_gps) ct,
-      row_number() over (partition by id_veiculo, timestamp_gps) rn
-  from flags
-  ),
-  provavel as (
-    select 
-        id_veiculo,
-        timestamp_gps,
-        linha,
-        CASE
-          WHEN ct>1
-          THEN    
-              CASE 
-              WHEN most_true = max(most_true) over(partition by id_veiculo, timestamp_gps order by rn) 
-              AND lead(most_true) over(partition by id_veiculo, timestamp_gps order by rn) < max(most_true) over(
-                    partition by id_veiculo, timestamp_gps order by rn)
-              THEN linha 
-              WHEN most_true = lead(most_true) over(partition by id_veiculo, timestamp_gps order by rn)
-              THEN linha
-              ELSE lead(linha) over(partition by id_veiculo, timestamp_gps order by rn) end
-          WHEN ct = 1
-          THEN linha
-        END AS linha_provavel
-    FROM counts
-  )
-SELECT
-  f.* except(linha),
-  f.linha as servico
-FROM
-  flags f
-JOIN
-  provavel P
-ON
-  f.id_veiculo = p.id_veiculo
-  AND f.timestamp_gps = p.timestamp_gps
-  AND f.linha = p.linha_provavel
+  

--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_flag_trajeto_correto.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_flag_trajeto_correto.sql
@@ -68,7 +68,7 @@ WITH
     -- 5. Agregação com LOGICAL_OR para evitar duplicação de registros
     SELECT
       id_veiculo,
-      linha,
+      linha as servico,
       linha_gtfs,
       route_id,
       data,

--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_parada.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_parada.sql
@@ -39,7 +39,7 @@ WITH
       nome_parada, 
       tipo_parada,
       ROUND(ST_DISTANCE(posicao_veiculo_geo, ponto_parada), 1) distancia_parada,
-      ROW_NUMBER() OVER (PARTITION BY timestamp_gps, id_veiculo ORDER BY ST_DISTANCE(posicao_veiculo_geo, ponto_parada)) nrow
+      ROW_NUMBER() OVER (PARTITION BY timestamp_gps, id_veiculo, linha ORDER BY ST_DISTANCE(posicao_veiculo_geo, ponto_parada)) nrow
     FROM terminais p
     JOIN (
       SELECT *

--- a/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_parada.sql
+++ b/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_parada.sql
@@ -39,7 +39,7 @@ WITH
       nome_parada, 
       tipo_parada,
       ROUND(ST_DISTANCE(posicao_veiculo_geo, ponto_parada), 1) distancia_parada,
-      ROW_NUMBER() OVER (PARTITION BY timestamp_gps, id_veiculo, linha ORDER BY ST_DISTANCE(posicao_veiculo_geo, ponto_parada)) nrow
+      ROW_NUMBER() OVER (PARTITION BY timestamp_gps, id_veiculo, servico ORDER BY ST_DISTANCE(posicao_veiculo_geo, ponto_parada)) nrow
     FROM terminais p
     JOIN (
       SELECT *

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_parada.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_parada.sql
@@ -40,7 +40,7 @@ WITH
       nome_parada, 
       tipo_parada,
       ROUND(ST_DISTANCE(posicao_veiculo_geo, ponto_parada), 1) distancia_parada,
-      ROW_NUMBER() OVER (PARTITION BY timestamp_gps, id_veiculo ORDER BY ST_DISTANCE(posicao_veiculo_geo, ponto_parada)) nrow
+      ROW_NUMBER() OVER (PARTITION BY timestamp_gps, id_veiculo, linha ORDER BY ST_DISTANCE(posicao_veiculo_geo, ponto_parada)) nrow
     FROM terminais p
     JOIN (
       SELECT 


### PR DESCRIPTION
Descrição:
Nas tabelas `aux_registros_flag_trajeto_correto` havia uma etapa de filtragem na qual, quando um veículo apresentasse dois sinais simultâneos de gps informando serviços distintos, apenas um era escolhido segundo um critério heurístico. 
Este filtro foi removido e, além disso, foi encontrado um bug nas tabelas `aux_registros_parada` onde, no mesmo caso de sinais simultâneos com serviços distintos, apenas o sinal que tivesse  a menor distância de uma parada/terminal era selecionado. Esse bug também foi corrigido e agora os sinais duplicados não são filtrados e permanecem na tabela tratada final `gps_<modo>`
As tabelas geradas após as modificações estão disponíveis em `rj-smtr-dev`