### PR TITLE
[smtr][onibus_gps] fix: remove filtros de 1 minuto entre captura e envio

### DIFF
--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_filtrada.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_filtrada.sql
@@ -35,7 +35,6 @@ gps AS (
   WHERE
     data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
     AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-    AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
   {%- endif -%}
 ),
 filtrada AS (

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_flag_trajeto_correto.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_flag_trajeto_correto.sql
@@ -37,7 +37,6 @@ WITH
     WHERE
       data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
     AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-    AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
     {%- endif -%}
   ),
   intersec AS (

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_velocidade.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_velocidade.sql
@@ -54,7 +54,6 @@ with
     WHERE
         data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
     AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-    AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
     {%- endif -%}
     ),
     medias as (

--- a/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
+++ b/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
@@ -38,7 +38,6 @@ WITH
     WHERE
       data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
       AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-      AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
     {%- endif -%}
   ),
   velocidades AS (
@@ -137,5 +136,4 @@ ON
   WHERE
   date(r.timestamp_gps) between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
   AND r.timestamp_gps > "{{var('date_range_start')}}" and r.timestamp_gps <="{{var('date_range_end')}}"
-  AND DATETIME_DIFF(r.timestamp_captura, r.timestamp_gps, MINUTE) BETWEEN 0 AND 1
 {%- endif -%}


### PR DESCRIPTION
### Changelog
- Remove filtro `datetime_diff` dos modelos `onibus_gps` e `veiculos.gps_sppo`

### Contexto
O tratamento dos dados de gps do SPPO contavam com um filtro para que a diferença maxima permitida entre timestamp_gps e timestamp_captura fosse de 1 minuto. Com os novos parâmetros de captura, estes filtros fazem com que as consultas retornem nenhuma linha. aqui, estes filtros são removidos.