### PR TITLE
[onibus_gps] feat: Adiciona realocação de linhas na SPPO

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -39,6 +39,7 @@ vars:
   polygon_garagem: "rj-smtr.br_rj_riodejaneiro_geo.garagens_polygon" # aux_registros_parada
   sppo_terminais: "rj-smtr.br_rj_riodejaneiro_transporte.terminais_onibus_coordenadas" # aux_registros_parada
   sppo_registros_staging: "rj-smtr-staging.br_rj_riodejaneiro_onibus_gps_staging.registros"
+  sppo_realocacao_staging: "rj-smtr-dev.br_rj_riodejaneiro_onibus_gps_staging.realocacao" # TODO: mudar para prod
 
   # Parametros de intersecção do ônibus com rota
   ## Tamanho do buffer da rota

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_flag_trajeto_correto.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_flag_trajeto_correto.sql
@@ -66,7 +66,7 @@ WITH
     FROM registros r
     LEFT JOIN (
       SELECT * 
-      FROM {{ ref('shapes_geom') }}
+      FROM `rj-smtr.br_rj_riodejaneiro_sigmob.shapes_geom` -- {{ ref('shapes_geom') }} -- todo: mudar para prod
       WHERE id_modal_smtr in ({{ var('sppo_id_modal_smtr')|join(', ') }})
       AND data_versao = "{{ var('versao_fixa_sigmob')}}"
     ) s

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_realocacao.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_realocacao.sql
@@ -1,0 +1,66 @@
+{{ 
+  config(
+      materialized='incremental',
+      partition_by={
+            "field":"data",
+            "data_type": "date",
+            "granularity":"day"
+      },
+      incremental_strategy='insert_overwrite'
+  )
+}}
+
+-- 1. Filtra realocações válidas dentro do intervalo de GPS avaliado
+with realocacao as (
+  select 
+    *
+  from
+    {{ ref('sppo_realocacao') }}
+  where
+    -- Realocação deve acontecer após o registro de GPS e até 1 hora depois
+        datetime_diff(datetime_operacao, datetime_entrada, minute) between 0 and 60
+    and 
+        data between DATE("{{var('date_range_start')}}")
+        and DATE(datetime_add("{{var('date_range_end')}}", interval 1
+        hour))
+    and 
+        datetime_operacao between datetime("{{var('date_range_start')}}")
+            and datetime_add("{{var('date_range_end')}}", interval 1 hour)
+),
+-- 2. Altera registros de GPS com servicos realocados
+gps as (
+  select
+    ordem,
+    timestamp_gps,
+    linha
+  from {{ ref('sppo_registros') }}
+  where
+    data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
+    and timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <= "{{var('date_range_end')}}"
+),
+combinacao as (
+  select
+    r.id_veiculo,
+    g.timestamp_gps,
+    g.linha as servico_gps,
+    r.servico as servico_realocado,
+    r.datetime_operacao as timestamp_realocacao,
+    r.data,
+    r.hora
+  from gps g
+  inner join realocacao r
+  on 
+    g.ordem = r.id_veiculo
+    and g.linha != r.servico
+    and g.timestamp_gps between r.datetime_entrada and r.datetime_saida
+)
+-- Filtra realocacao mais recente para cada timestamp
+select
+  * except(rn)
+from (
+  select 
+    *,
+    row_number() over (partition by id_veiculo, timestamp_gps order by timestamp_realocacao desc) as rn
+  from combinacao
+)
+where rn = 1

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_realocacao.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_realocacao.sql
@@ -1,0 +1,15 @@
+SELECT 
+  SAFE_CAST(id_veiculo AS STRING) id_veiculo,
+  SAFE_CAST(datetime_operacao AS DATETIME) datetime_operacao,
+  concat(
+    ifnull(REGEXP_EXTRACT(servico, r'[A-Z]+'), ""), 
+    ifnull(REGEXP_EXTRACT(servico, r'[0-9]+'), "") 
+  ) as servico,
+  SAFE_CAST(datetime_entrada AS DATETIME) as datetime_entrada,
+  SAFE_CAST(datetime_saida AS DATETIME) as datetime_saida,
+  SAFE_CAST(DATETIME(TIMESTAMP(timestamp_processamento), "America/Sao_Paulo") AS DATETIME) as timestamp_processamento,
+  SAFE_CAST(DATETIME(TIMESTAMP(timestamp_captura), "America/Sao_Paulo") AS DATETIME) as timestamp_captura,
+  data,
+  hora
+FROM
+  {{var('sppo_realocacao_staging')}} as t

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_realocacao.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_realocacao.sql
@@ -1,12 +1,12 @@
 SELECT 
   SAFE_CAST(id_veiculo AS STRING) id_veiculo,
-  SAFE_CAST(datetime_operacao AS DATETIME) datetime_operacao,
+  SAFE_CAST(DATETIME(TIMESTAMP(datetime_operacao), "America/Sao_Paulo") AS DATETIME) datetime_operacao,
   concat(
     ifnull(REGEXP_EXTRACT(servico, r'[A-Z]+'), ""), 
     ifnull(REGEXP_EXTRACT(servico, r'[0-9]+'), "") 
   ) as servico,
-  SAFE_CAST(datetime_entrada AS DATETIME) as datetime_entrada,
-  SAFE_CAST(datetime_saida AS DATETIME) as datetime_saida,
+  SAFE_CAST(DATETIME(TIMESTAMP(datetime_entrada), "America/Sao_Paulo") AS DATETIME) as datetime_entrada,
+  SAFE_CAST(DATETIME(TIMESTAMP(datetime_saida), "America/Sao_Paulo") AS DATETIME) as datetime_saida,
   SAFE_CAST(DATETIME(TIMESTAMP(timestamp_processamento), "America/Sao_Paulo") AS DATETIME) as timestamp_processamento,
   SAFE_CAST(DATETIME(TIMESTAMP(timestamp_captura), "America/Sao_Paulo") AS DATETIME) as timestamp_captura,
   data,

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_registros.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_registros.sql
@@ -4,7 +4,10 @@ SELECT
     SAFE_CAST(REPLACE(longitude, ',', '.') AS FLOAT64) longitude,
     SAFE_CAST(DATETIME(TIMESTAMP(datahora), "America/Sao_Paulo") AS DATETIME) timestamp_gps,
     SAFE_CAST(velocidade AS INT64) velocidade,
-    SAFE_CAST(linha AS STRING) linha,
+    concat(
+        ifnull(REGEXP_EXTRACT(linha, r'[A-Z]+'), ""), 
+        ifnull(REGEXP_EXTRACT(linha, r'[0-9]+'), "") 
+    ) as linha,
     SAFE_CAST(DATETIME(TIMESTAMP(timestamp_captura), "America/Sao_Paulo") AS DATETIME) timestamp_captura,
     SAFE_CAST(data AS DATE) data,
     SAFE_CAST(hora AS INT64) hora

--- a/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
+++ b/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
@@ -73,7 +73,7 @@ SELECT
   date(r.timestamp_gps) data,
   extract(time from r.timestamp_gps) hora, 
   r.id_veiculo,
-  replace(r.linha, " ", "") as servico,
+  r.linha as servico,
   r.latitude,
   r.longitude,
   CASE 


### PR DESCRIPTION
## Descrição
Adiciona a etapa de realocação das linhas na materialização dos registros de GPS dos ônibus (SPPO).

## Changelog
- Cria a tabela de realocações válidas por período: `sppo_aux_registros_realocacao`
- Inclui registros realocados na `sppo_aux_registros_filtrada`
- Padroniza tratamento da `linha` em `sppo_registros` para serviço + linha, sem espaçamento

## TODO
- [ ] Adicionar descrição das colunas no `schema.yml`

---

Co-authored-by: @eng-rodrigocunha engtransportes.rodrigocunha@gmail.com
Co-authored by:  @Hellcassius caiorogerio.santos@gmail.com