### PR TITLE
[smtr][gtfs] Criar tabela `shapes_with_stops` no GTFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dbt-env/
 # CONFIG
 .DS_Store
 .vscode/
+*.cpython-*
 
 # DEV
 scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dbt-env/
 scripts/
 dev/profiles.yml
 dev/.user.yml
+credentials*/
+profiles*/

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,3 @@ dbt-env/
 scripts/
 dev/profiles.yml
 dev/.user.yml
-credentials*/
-profiles*/

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ pip install -r requirements-dev.txt
 * Configure suas credenciais para leitura/escrita no datalake:
 
 ```bash
+# crie a pasta de configuração
+mkdir -p profiles-dev
 # copie o arquivo de exemplo
-cp dev/profiles-example.yml dev/profiles.yml
+cp dev/profiles-example.yml profiles-dev/profiles.yml
 # preencha com suas credenciais
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,8 @@ pip install -r requirements-dev.txt
 * Configure suas credenciais para leitura/escrita no datalake:
 
 ```bash
-# crie a pasta de configuração
-mkdir -p profiles-dev
 # copie o arquivo de exemplo
-cp dev/profiles-example.yml profiles-dev/profiles.yml
+cp dev/profiles-example.yml dev/profiles.yml
 # preencha com suas credenciais
 ```
 

--- a/dev/run.py
+++ b/dev/run.py
@@ -1,7 +1,7 @@
 from utils import run_dbt_model
 import os
 
-# Veja os parâmetros disponíveis da função run_dbt_model em util.py
+# Veja os parâmetros disponíveis da função run_dbt_model em utils.py
 
 run_dbt_model(
     dataset_id="example",

--- a/models/gtfs/schema.yml
+++ b/models/gtfs/schema.yml
@@ -1,0 +1,18 @@
+
+version: 2
+
+models:
+  - name: shapes_with_stops
+    description: "Shapes with stops"
+    columns:
+      - name: trip_id
+        description: "The composite primary key for this table"
+
+      - name: stop_id
+        description: "The composite primary key for this table"
+
+      - name: latitude
+        description: "shape_pt_lat"
+
+      - name: longitude
+        description: "shape_pt_lon"

--- a/models/gtfs/shapes_with_stops.sql
+++ b/models/gtfs/shapes_with_stops.sql
@@ -1,0 +1,77 @@
+
+-- 4. remove duplicates, keep with min distance
+SELECT *
+    EXCEPT (
+        -- Remove extra columns
+        min_distance,
+        distance
+    )
+FROM
+(
+    -- 3. set min distance
+    SELECT *,
+        MIN(distance) OVER (PARTITION BY stop_id) AS min_distance
+    FROM
+    (
+        -- 2. shapes_with_stops with distance
+        SELECT
+            SAFE_CAST(stoptimes.trip_id AS STRING) as trip_id,
+            SAFE_CAST(stoptimes.stop_id AS STRING) as stop_id,
+            SAFE_CAST(stops.stop_name AS STRING) as stop_name,
+            SAFE_CAST(shapes.shape_pt_lat AS FLOAT64) AS latitude,
+            SAFE_CAST(shapes.shape_pt_lon AS FLOAT64) AS longitude,
+            SAFE_CAST(shapes.shape_dist_traveled AS INT) as shape_dist_traveled,
+            SAFE_CAST(stoptimes.stop_sequence AS INT64) as stop_sequence,
+            SAFE_CAST(routes.route_id AS INT) as route_id,
+            SAFE_CAST(routes.route_short_name AS INT) as route_short_name,
+            SAFE_CAST(routes.route_long_name AS INT) as route_long_name,
+            SAFE_CAST(previous_stop_id AS STRING) as previous_stop_id,
+            SAFE_CAST(previous_stop_name AS STRING) as previous_stop_name,
+            SAFE_CAST(next_stop_id AS STRING) as next_stop_id,
+            SAFE_CAST(next_stop_name AS STRING) as next_stop_name,
+
+            -- extra cols, for debug
+            -- SAFE_CAST(DATETIME(TIMESTAMP(stoptimes.timestamp_captura), "America/Sao_Paulo") AS DATETIME) timestamp_captura,
+            -- SAFE_CAST(shapes.shape_id AS STRING) AS shape_id,
+            -- SAFE_CAST(shapes.shape_pt_lat AS FLOAT64) AS shape_pt_lat,
+            -- SAFE_CAST(shapes.shape_pt_lon AS FLOAT64) AS shape_pt_lon,
+            -- SAFE_CAST(stops.stop_lat AS FLOAT64) AS stop_lat,
+            -- SAFE_CAST(stops.stop_lon AS FLOAT64) AS stop_lon,
+            -- SAFE_CAST(previous_stop_sequence AS INT64) AS previous_stop_sequence,
+            -- SAFE_CAST(next_stop_sequence AS INT64) AS next_stop_sequence,
+            ST_DISTANCE(
+                ST_GEOGPOINT(SAFE_CAST(shape_pt_lon AS FLOAT64), SAFE_CAST(shape_pt_lat AS FLOAT64)),
+                ST_GEOGPOINT(SAFE_CAST(stop_lon AS FLOAT64), SAFE_CAST(stop_lat AS FLOAT64))
+            ) AS distance
+        FROM
+        (
+            -- 1. stoptimes with extra cols
+            SELECT *,
+                (SELECT stop_name FROM {{ var('stops_staging') }} WHERE stop_id = previous_stop_id) AS previous_stop_name,
+                (SELECT stop_name FROM {{ var('stops_staging') }} WHERE stop_id = next_stop_id) AS next_stop_name,
+            FROM (
+                SELECT stoptimes_1.*,
+                    stops.stop_name,
+                    LAG(SAFE_CAST(stoptimes_1.stop_sequence AS INT64)) OVER (PARTITION BY SAFE_CAST(stoptimes_1.trip_id AS STRING) ORDER BY SAFE_CAST(stoptimes_1.stop_sequence AS INT64)) AS previous_stop_sequence,
+                    LEAD(SAFE_CAST(stoptimes_1.stop_sequence AS INT64)) OVER (PARTITION BY SAFE_CAST(stoptimes_1.trip_id AS STRING) ORDER BY SAFE_CAST(stoptimes_1.stop_sequence AS INT64)) AS next_stop_sequence,
+                    LAG(SAFE_CAST(stoptimes_1.stop_id AS STRING)) OVER (PARTITION BY SAFE_CAST(stoptimes_1.trip_id AS STRING) ORDER BY SAFE_CAST(stoptimes_1.stop_sequence AS INT64)) AS previous_stop_id,
+                    LEAD(SAFE_CAST(stoptimes_1.stop_id AS STRING)) OVER (PARTITION BY SAFE_CAST(stoptimes_1.trip_id AS STRING) ORDER BY SAFE_CAST(stoptimes_1.stop_sequence AS INT64)) AS next_stop_id,
+                FROM {{ var('stop_times_staging') }} stoptimes_1
+                JOIN {{ var('stops_staging') }} stops ON (stops.timestamp_captura BETWEEN '2022-12-27 10:00:00-03:00' AND '2022-12-27 11:00:00-03:00'  AND stops.stop_id = stoptimes_1.stop_id)
+                WHERE stoptimes_1.timestamp_captura BETWEEN '2022-12-27 10:00:00-03:00' AND '2022-12-27 11:00:00-03:00' 
+            )
+            ORDER BY trip_id, SAFE_CAST(stop_sequence AS INT64)
+            -- 1
+        ) stoptimes
+            JOIN {{ var('trips_staging') }} trips ON (SAFE_CAST(trips.trip_id AS STRING) = stoptimes.trip_id AND stoptimes.timestamp_captura BETWEEN '2022-12-27 10:00:00-03:00' AND '2022-12-27 11:00:00-03:00' )
+            JOIN {{ var('stops_staging') }} stops ON (SAFE_CAST(stoptimes.stop_id AS STRING) = stops.stop_id AND stops.timestamp_captura BETWEEN '2022-12-27 10:00:00-03:00' AND '2022-12-27 11:00:00-03:00' )
+            JOIN {{ var('shapes_staging') }} shapes ON (SAFE_CAST(trips.shape_id AS STRING) = shapes.shape_id AND shapes.timestamp_captura BETWEEN '2022-12-27 10:00:00-03:00' AND '2022-12-27 11:00:00-03:00' )
+            JOIN {{ var('routes_staging') }} routes ON (SAFE_CAST(trips.route_id AS STRING) = routes.route_id AND routes.timestamp_captura BETWEEN '2022-12-27 10:00:00-03:00' AND '2022-12-27 11:00:00-03:00' )
+        -- 2
+    )
+    ORDER BY stop_id, stop_sequence, trip_id
+    -- 3
+)
+WHERE distance = min_distance
+LIMIT 2
+-- 4


### PR DESCRIPTION
## Motivo
Entendeu-se que é interessante criar a tabela e copiar para o banco de dados do servidor mobilidade-rio-api, pois esta consulta demora 20 minutos ou mais para renderizar. O servidor irá consultar os dados prontos direto do banco, economizando tempo.

## Changelog
- README: Copiar de `dev/profiles-example.yml` para `profiles-dev/profiles.yml`, seguindo o padrão usado em [profiles.yml ](https://github.com/prefeitura-rio/queries-rj-smtr/blob/staging/smtr-add-gtfs/profiles.yml)(da pasta raiz)
- Modelo e `schema.yml` de shapes_with_stops
- gitignore - ignorar arquivos de log `.cpython` e pastas sensíveis como `credentials-dev` e `profiles-dev`..

## Checklist

- [x] Testar os modelos no BigQuery
- [x] Testar os modelos no dbt
- [x] Validar alterações

📆 Criar pipeline no Prefect (será feito após o PR)

PR recusado, aplicar alterações
  - [x] Desfazer mudanças referentes às pastas `credentials-dev` e `profiles-dev`.
  - [ ] Retirar o `SAFE_CAST` de variáveis no sql, desde que não altere o resultado da query.
  - [ ] Trocar, no DBT, o uso de `var()` por `ref()` das tabelas em models.gtfs

Terefas extras ([veja o comentário](https://github.com/prefeitura-rio/queries-rj-smtr/pull/57#issuecomment-1387169817))
- [ ] Revisar a query, testando se as subqueries obtém o resultado esperado
- [ ] Validar a query de forma apropriada (pode ser necessário elaborar um critério de validação)