### PR TITLE
[projeto_subsidio_sppo] Refatora tratamento de viagens circulares (nova versão do GTFS)

### DIFF
--- a/models/projeto_subsidio_sppo/aux_viagem_inicio_fim.sql
+++ b/models/projeto_subsidio_sppo/aux_viagem_inicio_fim.sql
@@ -54,7 +54,7 @@ inicio_fim AS (
 )
 -- 4. Filtra colunas e cria campo identificador da viagem (id_viagem)
 select distinct
-    concat(id_veiculo, "-", servico_realizado ,"-", sentido, "-", shape_id, "-", FORMAT_DATETIME("%Y%m%d%H%M%S", datetime_partida)) as id_viagem,
+    concat(id_veiculo, "-", servico_realizado ,"-", sentido, "-", shape_id_planejado, "-", FORMAT_DATETIME("%Y%m%d%H%M%S", datetime_partida)) as id_viagem,
     data,
     id_empresa,
     id_veiculo,

--- a/models/projeto_subsidio_sppo/viagem_planejada.sql
+++ b/models/projeto_subsidio_sppo/viagem_planejada.sql
@@ -80,7 +80,7 @@ quadro_trips as (
         select
             * except(trip_id),
             trip_id as trip_id_planejado,
-            concat(SUBSTR(trip_id, 1, 10), "I", SUBSTR(trip_id, 12, length(trip_id))) as trip_id,
+            concat(trip_id, "_0") as trip_id,
         from
             quadro
         where sentido = "C"
@@ -89,7 +89,7 @@ quadro_trips as (
         select
             * except(trip_id),
             trip_id as trip_id_planejado,
-            concat(SUBSTR(trip_id, 1, 10), "V", SUBSTR(trip_id, 12, length(trip_id))) as trip_id,
+            concat(trip_id, "_1") as trip_id,
         from
             quadro
         where sentido = "C"
@@ -101,7 +101,7 @@ quadro_tratada as (
         t.shape_id,
         case 
             when sentido = "C"
-            then concat(SUBSTR(shape_id, 1, 10), "C", SUBSTR(shape_id, 12, length(shape_id))) 
+            then split(shape_id, "_")[offset(0)]
             else shape_id
         end as shape_id_planejado, -- TODO: adicionar no sigmob
     from
@@ -122,7 +122,11 @@ shapes as (
         data_versao as data_shape,
         shape_id,
         shape,
-        SUBSTR(shape_id, 11, 1) as sentido_shape,
+        case 
+            when sentido = "C"
+            split(shape_id, "_")[offset(1)]
+            else sentido_shape
+        end as sentido_shape,
         start_pt,
         end_pt
     from 

--- a/models/projeto_subsidio_sppo/viagem_planejada.sql
+++ b/models/projeto_subsidio_sppo/viagem_planejada.sql
@@ -123,9 +123,9 @@ shapes as (
         shape_id,
         shape,
         case 
-            when sentido = "C"
-            split(shape_id, "_")[offset(1)]
-            else sentido_shape
+            when sentido = "C" and split(shape_id, "_")[offset(1)] = "0" then "I"
+            when sentido = "C" and split(shape_id, "_")[offset(1)] = "1" then "V"
+            when sentido = "I" or sentido = "V" then sentido
         end as sentido_shape,
         start_pt,
         end_pt


### PR DESCRIPTION
## Changelog

- Refatora `trip_id` e `shape_id` de serviço circulares conforme direction_id: _0 para ida, _1 para volta

Extras:
- Incorpora `shape_id_planejado` no `id_viagem`: para tratamento de multiplos shapes planejados (i.e. réveillon), mas ja pode ser extendido para outros casos
- Trata % de KM para datas cujos serviços nao foram planejados: neste ultimo QH vieram entradas com KM total zerada (cujo serviço nao foi planejado para a data). Escolhemos mante-las no planejado, porem nao apurar o valor das mesmas na sumario
