### PR TITLE
[dashboard_subsidio_sppo] hotfix: corrige status sumario_servico_tipo_viagem_dia + sumario_servico_dia_tipo

### DIFF
--- a/models/dashboard_subsidio_sppo/sumario_servico_dia_tipo.sql
+++ b/models/dashboard_subsidio_sppo/sumario_servico_dia_tipo.sql
@@ -137,21 +137,26 @@ WITH
   SELECT
     indicadores,
     status_array,
-    status_array[
-  OFFSET
-    (0)] AS status
+    status_array[OFFSET(0)] AS status
   FROM
     tabela_status_array),
+  status_flat AS (
+  SELECT DISTINCT 
+    status_t, 
+    status 
+  FROM 
+    status_update, 
+    UNNEST(status_array) AS status_t),
   servico_km_tipo_atualizado AS (
   SELECT
-    * EXCEPT(tipo_viagem),
+    k.* EXCEPT(tipo_viagem),
     u.status AS tipo_viagem
   FROM
     servico_km_tipo AS k
   LEFT JOIN
-    status_update AS u
-  ON
-    k.tipo_viagem IN UNNEST(u.status_array)),
+    status_flat AS u
+  ON 
+    u.status_t = k.tipo_viagem),
   servico_km AS (
   SELECT
     p.data,

--- a/models/dashboard_subsidio_sppo/sumario_servico_tipo_viagem_dia.sql
+++ b/models/dashboard_subsidio_sppo/sumario_servico_tipo_viagem_dia.sql
@@ -78,6 +78,13 @@ WITH
     status_array[OFFSET(0)] AS status
   FROM
     tabela_status_array),
+  status_flat AS (
+      SELECT DISTINCT 
+        status_t, 
+        status 
+      FROM 
+        status_update, 
+        UNNEST(status_array) AS status_t),
   tipo_viagem_v2_atualizado AS (
   SELECT
     * EXCEPT(status),
@@ -85,9 +92,9 @@ WITH
   FROM
     tipo_viagem_v2 AS k
   LEFT JOIN
-    status_update AS u
-  ON
-    k.status IN UNNEST(u.status_array)),
+    status_flat AS u
+  ON 
+    u.status_t = k.status),
   sumario_v2 AS (
   SELECT
     v.`data`,


### PR DESCRIPTION
Corrige status duplicado (que consequentemente duplicava a quantidade de viagens) das tabelas `sumario_servico_tipo_viagem_dia` e `sumario_servico_dia_tipo` no model `dashboard_subsidio_sppo`.