### PR TITLE
[dashboard_subsidio_sppo] hotfix: sumarios

### DIFF
--- a/models/dashboard_subsidio_sppo/sumario_servico_dia_tipo.sql
+++ b/models/dashboard_subsidio_sppo/sumario_servico_dia_tipo.sql
@@ -67,7 +67,8 @@ WITH
   WHERE
     DATA BETWEEN DATE( "{{ var("DATA_SUBSIDIO_V2_INICIO") }}" )
     AND DATE( "{{ var("end_date") }}" )
-    AND distancia_total_planejada > 0 ),
+    AND (distancia_total_planejada > 0
+    OR distancia_total_planejada IS NOT NULL) ),
   veiculos AS (
   SELECT
     DATA,

--- a/models/dashboard_subsidio_sppo/sumario_servico_tipo_viagem_dia.sql
+++ b/models/dashboard_subsidio_sppo/sumario_servico_tipo_viagem_dia.sql
@@ -10,7 +10,8 @@ WITH
     {{ ref("viagem_planejada") }}
   WHERE
     `data` <= DATE( "{{ var("end_date") }}" )
-    AND distancia_total_planejada is not null ),
+    AND (distancia_total_planejada > 0
+    OR distancia_total_planejada IS NOT NULL) ),
   sumario_v1 AS ( -- Viagens v1
   SELECT
     `data`,
@@ -130,14 +131,16 @@ LEFT JOIN
   sumario_v1 v1
 ON
   p.`data` = v1.`data`
-  AND p.servico = v1.servico)
+  AND p.servico = v1.servico
+WHERE
+  p.`data` < DATE( "{{ var("DATA_SUBSIDIO_V2_INICIO") }}" ))
 UNION ALL
 (SELECT
   p.`data`,
   p.tipo_dia,
   p.consorcio,
   p.servico,
-  IFNULL(v2.tipo_viagem, "Não identificada") AS tipo_viagem,
+  IFNULL(v2.tipo_viagem, "Sem viagem apurada") AS tipo_viagem,
   v2.indicador_ar_condicionado,
   IFNULL(v2.viagens, 0) AS viagens,
   IFNULL(v2.km_apurada, 0) AS km_apurada
@@ -147,4 +150,6 @@ LEFT JOIN
   sumario_v2 v2
 ON
   p.`data` = v2.`data`
-  AND p.servico = v2.servico)
+  AND p.servico = v2.servico
+WHERE
+  p.`data` >= DATE( "{{ var("DATA_SUBSIDIO_V2_INICIO") }}" ))


### PR DESCRIPTION
- Insere `distancia_total_planejada > 0 OR distancia_total_planejada IS NOT NULL` para atender ao planejamento de datas anteriores
- Corrige `sumario_servico_tipo_viagem_dia` para não duplicar os serviços planejados em períodos diferentes