### PR TITLE
Adiciona tabelas do relatório SPPO para CIMU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dbt-env/
 # DEV
 scripts/
 dev/
+dev/run.py

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -161,3 +161,6 @@ models:
     br_rj_riodejaneiro_rdo:
       +materialized: view
       +schema: br_rj_riodejaneiro_rdo
+    dashboard_cimu:
+      +materialized: view
+      +schema: dashboard_cimu

--- a/models/dashboard_cimu/README.md
+++ b/models/dashboard_cimu/README.md
@@ -1,0 +1,29 @@
+# Dashboard CIMU
+* Versão: 0.1
+* Data de início: 20/06/2023
+* Autor: Igor Laltuf
+
+## Descrição
+Este repositório contém a documentação do conjunto de dados utilizados no dashboard do Centro Integrado de Mobilidade Urbana (CIMU).
+
+
+## Sobre os dados
+
+### 1 - Tabela sumario_servico_dia_2022
+
+Contém os dados dos subsídios desde o início da apuração até 15-01-2023.
+
+#### Tabelas de origem:
+rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico
+rj-smtr.dashboard_subsidio_sppo.sumario_servico_tipo_viagem_dia
+
+
+
+### 2 - Tabela sumario_servico_dia_2023TD
+
+Contém os dados dos subsídios a partir de 16-01-2023, excluindo o intervalo do carnaval de 17-02-2023 até 22-02-2023.
+
+#### Tabelas de origem:
+rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico
+rj-smtr.dashboard_subsidio_sppo.sumario_servico_tipo_viagem_dia
+

--- a/models/dashboard_cimu/schema.yml
+++ b/models/dashboard_cimu/schema.yml
@@ -1,0 +1,67 @@
+version: 2
+
+models:
+  - name: sumario_servico_dia_2022
+    description: "sumario_servico_dia_2022"
+    columns:
+      - name: data
+        description: "Data de emissão do sinal de GPS"
+      - name: tipo_dia
+        description: "Dia da semana considerado para o cálculo da distância planejada - categorias: Dia Útil, Sabado, Domingo"
+      - name: servico
+        description: "Serviço realizado pelo veículo"
+      - name: viagens
+        description: "Quantidade de viagens apuradas"
+      - name: km_apurada
+        description: "Distância apurada do serviço (km)
+        Distância planejada da viagem multiplicada pela quantidade de viagens"
+      - name: km_planejada
+        description: "Distância planejada para o serviço (km)"
+      - name: perc_km_planejada
+        description: "Indicador percentual de quilometragem apurada em relação à planejada da linha"
+      - name: valor_subsidio_pago
+        description: "Valor de subsídio apurado (R$)
+        Distância apurada do serviço multiplicada pelos respectivos valores pela classificação do veículo"
+      - name: consorcio
+        description: "Consórcio que opera o serviço"
+  - name: sumario_servico_dia_2023TD
+    description: "sumario_servico_dia_2023TD"
+    columns:
+      - name: data
+        description: "Data de emissão do sinal de GPS"
+      - name: tipo_dia
+        description: "Dia da semana considerado para o cálculo da distância planejada - categorias: Dia Útil, Sabado, Domingo"
+      - name: servico
+        description: "Serviço realizado pelo veículo"
+      - name: viagens
+        description: "Quantidade de viagens apuradas"
+      - name: km_apurada
+        description: "Distância apurada do serviço (km)
+        Distância planejada da viagem multiplicada pela quantidade de viagens"
+      - name: km_planejada
+        description: "Distância planejada para o serviço (km)"
+      - name: perc_km_planejada
+        description: "Indicador percentual de quilometragem apurada em relação à planejada da linha"  
+      - name: valor_subsidio_pago
+        description: "Valor de subsídio apurado (R$)
+        Distância apurada do serviço multiplicada pelos respectivos valores pela classificação do veículo"
+      - name: valor_penalidade
+        description: "Valor de penalidade apurado (R$)
+        Linha com operação entre 40% e 60% da quilometragem estipulada - penalidade equivalente a uma infração média prevista no Código Disciplinar do Serviço Público de Transporte de Passageiros por Meio de Ônibus do Município do Rio de Janeiro - SPPO.
+        Linha com operação inferior a 40% da quilometragem estipulada - penalidade equivalente a uma infração grave prevista no Código Disciplinar do Serviço Público de Transporte de Passageiros por Meio de Ônibus do Município do Rio de Janeiro - SPPO."
+      - name: valor_final_subsidio
+        description: "Valor final de subsídio (R$)
+        Diferença entre o valor de subsídio apurado e o valor das penalidades."
+      - name: consorcio
+        description: "Consórcio que opera o serviço"
+      - name: km_apurada_n_licenciado
+        description: "Distância apurada de viagens realizadas por veículo não licenciado (km)"
+      - name: km_viagens_veiculos_com_ar_inoperante
+        description: "Distância apurada de viagens realizadas por veículo licenciado com ar condicionado e autuado em razão de inoperância ou mau funcionamento deste (km)"
+      - name: km_apurada_licenciado_sem_ar
+        description: "Distância apurada de viagens realizadas por veículo licenciado sem ar condicionado (km)"
+      - name: km_apurada_licenciado_ar_autuado
+        description: "Distância apurada de viagens realizadas por veículo licenciado com ar condicionado e autuado em razão de inoperância ou mau funcionamento deste (km)"
+      - name: km_apurada_licenciado_ar_n_autuado
+        description: "Distância apurada de viagens realizadas por veículo licenciado com ar condicionado e não autuado em razão de inoperância ou mau funcionamento deste (km)"
+

--- a/models/dashboard_cimu/sumario_servico_dia_2022.sql
+++ b/models/dashboard_cimu/sumario_servico_dia_2022.sql
@@ -1,0 +1,35 @@
+/*  View com dados de 2022*/ 
+
+SELECT
+  s.`data`,
+  s.tipo_dia,
+  s.servico,
+  CAST(s.viagens AS INT) AS viagens,
+  ROUND(s.km_apurada, 2) AS km_apurada,
+  ROUND(km_planejada, 2) AS km_planejada,
+  ROUND(perc_km_planejada, 2) AS perc_km_planejada,
+  ROUND(valor_subsidio_pago, 2) AS valor_subsidio_pago,
+  t.consorcio  
+FROM
+  `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico` s
+LEFT JOIN (
+  SELECT DISTINCT
+    data,
+    servico,
+    consorcio,
+    km_apurada
+  FROM
+    `rj-smtr.dashboard_subsidio_sppo.sumario_servico_tipo_viagem_dia`
+) t ON s.servico = t.servico AND s.`data` = t.`data`
+WHERE
+  s.`data` < '2023-01-16' 
+GROUP BY
+  s.`data`,
+  s.tipo_dia,
+  s.servico,
+  viagens,
+  km_apurada,
+  km_planejada,
+  perc_km_planejada,
+  valor_subsidio_pago,
+  t.consorcio

--- a/models/dashboard_cimu/sumario_servico_dia_2023TD.sql
+++ b/models/dashboard_cimu/sumario_servico_dia_2023TD.sql
@@ -1,0 +1,45 @@
+/* View com dados a partir de 2023 (To Date) */
+
+SELECT
+  s.`data`,
+  s.tipo_dia,
+  s.servico,
+  CAST(s.viagens AS INT) AS viagens,
+  ROUND(s.km_apurada, 2) AS km_apurada,
+  ROUND(km_planejada, 2) AS km_planejada,
+  ROUND(perc_km_planejada, 2) AS perc_km_planejada,
+  ROUND(valor_subsidio_pago, 2) AS valor_subsidio_pago,
+  ROUND(valor_penalidade, 2) AS valor_penalidade,
+  ROUND(valor_subsidio_pago + COALESCE(valor_penalidade, 0), 2) AS valor_final_subsidio,
+  t.consorcio,
+  COALESCE(MAX(CASE WHEN t.tipo_viagem = 'Licenciado com ar e autuado (023.II)' THEN t.km_apurada END), 0) AS km_apurada_licenciado_ar_autuado, /* ar inoperante*/
+  COALESCE(MAX(CASE WHEN t.tipo_viagem = 'Nao licenciado' THEN t.km_apurada END), 0) AS km_apurada_n_licenciado, /* É a coluna "km não identificado" no dash */
+  COALESCE(MAX(CASE WHEN t.tipo_viagem = 'Licenciado sem ar' THEN t.km_apurada END), 0) AS km_apurada_licenciado_sem_ar, /*sem ar*/
+  COALESCE(MAX(CASE WHEN t.tipo_viagem = 'Licenciado com ar e não autuado (023.II)' THEN t.km_apurada END), 0) AS km_apurada_licenciado_ar_n_autuado /*com ar*/
+FROM
+  `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico` s
+LEFT JOIN (
+  SELECT DISTINCT
+    data,
+    servico,
+    consorcio,
+    tipo_viagem,
+    km_apurada
+  FROM
+    `rj-smtr.dashboard_subsidio_sppo.sumario_servico_tipo_viagem_dia`
+) t ON s.servico = t.servico AND s.`data` = t.`data`
+WHERE
+  s.`data` >= '2023-01-16' 
+  AND s.`data` NOT BETWEEN '2023-02-17' AND '2023-02-22' /* remover intervalo do carnaval*/
+GROUP BY
+  s.`data`,
+  s.tipo_dia,
+  s.servico,
+  viagens,
+  km_apurada,
+  km_planejada,
+  perc_km_planejada,
+  valor_subsidio_pago,
+  valor_penalidade,
+  valor_final_subsidio,
+  t.consorcio


### PR DESCRIPTION
## Changelog
- Criação do readme
- Documentação de variáveis
- Criação dos modelos para 2022 e 2023 que vão alimentar o MVP do CIMU. 

TODO:
- [ ] Definir nomenclaturas
- [ ] Criar tabelas de `sumario_consorcio_dia_[nom_consorcio]`