### PR TITLE
[dashboard_subsidio_sppo] Atualização `sumario_servico_tipo_viagem_dia`

### DIFF
--- a/models/dashboard_subsidio_sppo/schema.yml
+++ b/models/dashboard_subsidio_sppo/schema.yml
@@ -70,6 +70,10 @@ models:
         description: "Serviço realizado pelo veículo"
       - name: tipo_viagem
         description: "Tipo de viagem"
+      - name: tipo_viagem_atualizado
+        description: "Tipo de viagem atualizado conforme nomenclatura mais atual"
+      - name: indicador_ar_condicionado	
+        description: "Indicador de veículo com ar condicionado"
       - name: viagens
         description: "Quantidade de viagens apuradas"
       - name: km_apurada

--- a/models/dashboard_subsidio_sppo/sumario_servico_tipo_viagem_dia.sql
+++ b/models/dashboard_subsidio_sppo/sumario_servico_tipo_viagem_dia.sql
@@ -85,8 +85,8 @@ WITH
     UNNEST(status_array) AS status_t),
   tipo_viagem_v2_atualizado AS (
   SELECT
-    * EXCEPT(status),
-    u.status
+    k.*,
+    u.status AS status_atualizado
   FROM
     tipo_viagem_v2 AS k
   LEFT JOIN
@@ -98,6 +98,7 @@ WITH
     v.`data`,
     v.servico,
     ve.status AS tipo_viagem,
+    ve.status_atualizado AS tipo_viagem_atualizado,
     ve.indicador_ar_condicionado,
     COUNT(id_viagem) AS viagens,
     ROUND(SUM(distancia_planejada), 2) AS km_apurada
@@ -112,7 +113,8 @@ WITH
     1,
     2,
     3,
-    4 )
+    4,
+    5 )
 (
 SELECT
   v1.`data`,
@@ -120,6 +122,7 @@ SELECT
   p.consorcio,
   v1.servico,
   COALESCE(v1.tipo_viagem, "Sem viagem apurada") AS tipo_viagem,
+  COALESCE(v1.tipo_viagem, "Sem viagem apurada") AS tipo_viagem_atualizado,
   SAFE_CAST(indicador_ar_condicionado AS BOOL) AS indicador_ar_condicionado,
   COALESCE(v1.viagens, 0) AS viagens,
   COALESCE(v1.km_apurada, 0) AS km_apurada
@@ -139,6 +142,7 @@ SELECT
   p.consorcio,
   v2.servico,
   COALESCE(v2.tipo_viagem, "Sem viagem apurada") AS tipo_viagem,
+  COALESCE(v2.tipo_viagem_atualizado, "Sem viagem apurada") AS tipo_viagem_atualizado,
   v2.indicador_ar_condicionado,
   COALESCE(v2.viagens, 0) AS viagens,
   COALESCE(v2.km_apurada, 0) AS km_apurada


### PR DESCRIPTION
Atualiza a tabela `sumario_servico_tipo_viagem_dia`, mantendo a nomenclatura de tipo de viagem atual (para fins de painel) e a anterior (para demais fins).