### PR TITLE
correção do serviço nas tabelas de gps e viagens

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -37,6 +37,14 @@ vars:
   sppo_registros_staging: "rj-smtr-staging.br_rj_riodejaneiro_onibus_gps_staging.registros"
   sppo_realocacao_staging: "rj-smtr-staging.br_rj_riodejaneiro_onibus_gps_staging.realocacao"
   data_inicio_realocacao: "2022-11-15"
+  sppo_aux_registros_filtrada: "rj-smtr.br_rj_riodejaneiro_onibus_gps.sppo_aux_registros_filtrada"
+  reprocessed_service: False # Set to 'true' to utilize the reprocessed gps table in dev
+  gps_sppo_reprocessado: "rj-smtr-dev.br_rj_riodejaneiro_veiculos_recursos_reprocessado.gps_sppo"
+  gps_sppo: "rj-smtr.br_rj_riodejaneiro_veiculos.gps_sppo"
+  viagem_planejada: "rj-smtr.projeto_subsidio_sppo.viagem_planejada"
+  servico_amostra: null
+  servico_apurado: null
+  id_veiculo_amostra: null
 
   # Parametros de intersecção do ônibus com rota
   ## Tamanho do buffer da rota
@@ -133,7 +141,7 @@ models:
   rj_smtr:
     projeto_subsidio_sppo:
       +materialized: view
-      +schema: projeto_subsidio_sppo
+      +schema: projeto_subsidio_sppo_recursos_reprocessado
     br_rj_riodejaneiro_sigmob:
       +materialized: view
       +schema: br_rj_riodejaneiro_sigmob
@@ -145,7 +153,7 @@ models:
       +schema: br_rj_riodejaneiro_brt_gps
     br_rj_riodejaneiro_veiculos:
       +materialized: view
-      +schema: br_rj_riodejaneiro_veiculos
+      +schema: br_rj_riodejaneiro_veiculos_recursos_reprocessado
     dashboard_subsidio_sppo:
       +materialized: view
       +schema: dashboard_subsidio_sppo
@@ -155,3 +163,5 @@ models:
     br_rj_riodejaneiro_rdo:
       +materialized: view
       +schema: br_rj_riodejaneiro_rdo
+
+      

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_flag_trajeto_correto.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_flag_trajeto_correto.sql
@@ -31,8 +31,7 @@ WITH
       data, 
       posicao_veiculo_geo, 
       timestamp_gps
-    FROM
-      {{ ref('sppo_aux_registros_filtrada') }} r 
+    FROM {{ var('sppo_aux_registros_filtrada') }} r 
     {% if not flags.FULL_REFRESH -%}
     WHERE
       data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
@@ -66,7 +65,7 @@ WITH
     FROM registros r
     LEFT JOIN (
       SELECT * 
-      FROM {{ ref('shapes_geom') }}
+      FROM `rj-smtr.br_rj_riodejaneiro_sigmob.shapes_geom` --{{ ref('shapes_geom') }}
       WHERE id_modal_smtr in ({{ var('sppo_id_modal_smtr')|join(', ') }})
       AND data_versao = "{{ var('versao_fixa_sigmob')}}"
     ) s

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_parada.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_parada.sql
@@ -49,8 +49,7 @@ WITH
         data, 
         linha, 
         posicao_veiculo_geo
-      FROM  
-        {{ ref('sppo_aux_registros_filtrada') }}
+      FROM {{ var('sppo_aux_registros_filtrada') }}      
       {%if not flags.FULL_REFRESH %}
       WHERE
         data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")

--- a/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_velocidade.sql
+++ b/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_velocidade.sql
@@ -48,8 +48,8 @@ with
                 SECOND
                 )),
             0
-        ) * 3.6 velocidade 
-    FROM  {{ ref("sppo_aux_registros_filtrada") }}
+        ) * 3.6 velocidade     
+    FROM {{ var('sppo_aux_registros_filtrada') }}   
     {%if not flags.FULL_REFRESH -%}
     WHERE
         data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")


### PR DESCRIPTION
## Changelog

- Esta modificação permite reprocessar as viagens e fazer a correção do código do serviço. 
- Ex: no GPS constava que o veículo operava o serviço 433, quando na verdade era a linha LECD50.

- Basta informar as variáveis contendo o id do veículo (id_veiculo_amostra), o número do serviço atribuído de forma errada pelas empresas no GPS (servico_amostra) e o serviço correto (servico_apurado). Também deve ser informado que a variável `reprocessed_service`é igual a true, para que a tabela de GPS reprocessada seja utilizada.


## Checklist

- [X] Já testei os modelos no BigQuery
- [ ] Já existe pipeline no Prefect
- [ ] Título do PR está 💯