### PR TITLE
Bilhetagem - Separa tabela de GPS validador van 

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -204,6 +204,9 @@ models:
     br_rj_riodejaneiro_bilhetagem_staging:
       +materialized: view
       +schema: br_rj_riodejaneiro_bilhetagem_staging
+    dashboard_bilhetagem_implantacao_jae:
+      +materialized: table
+      +schema: dashboard_bilhetagem_implantacao_jae
     br_rj_riodejaneiro_stu:
       +materialized: view
       +schema: br_rj_riodejaneiro_stu

--- a/models/br_rj_riodejaneiro_bilhetagem/gps_validador_van.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/gps_validador_van.sql
@@ -28,11 +28,21 @@ SELECT
     temperatura,
     '{{ var("version") }}' as versao
 FROM
-    {{ ref("gps_validador_aux") }}
+(
+    SELECT
+        *,
+        ROW_NUMBER() OVER(PARTITION BY id_transmissao_gps ORDER BY datetime_captura DESC) AS rn
+    FROM
+        {{ ref("gps_validador_aux") }}
+)
 WHERE
     {% if is_incremental() %}
         DATE(data) BETWEEN DATE("{{var('date_range_start')}}") AND DATE("{{var('date_range_end')}}")
         AND datetime_captura > DATETIME("{{var('date_range_start')}}") AND datetime_captura <= DATETIME("{{var('date_range_end')}}")
         AND
-    {%- endif %}
-    modo != "Van"
+    {% endif %}
+    rn = 1
+    AND modo = "Van"
+
+
+

--- a/models/br_rj_riodejaneiro_bilhetagem/integracao.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/integracao.sql
@@ -60,7 +60,7 @@ integracao_melt AS (
           {% for n in range(var('quantidade_integracoes_max')) %}
             STRUCT(
               {% for column, column_config in var('colunas_integracao').items() %}
-                {% if  column_config.select %}
+                {% if column_config.select %}
                   {{ column }}_t{{ n }} AS {{ column }},
                 {% endif %}
               {% endfor %}

--- a/models/br_rj_riodejaneiro_bilhetagem/schema.yml
+++ b/models/br_rj_riodejaneiro_bilhetagem/schema.yml
@@ -220,6 +220,47 @@ models:
         description: "Temperatura do local, medida pelo sensor do validador (ºC)"
       - name: versao
         description: "Código de controle de versão do dado (SHA Github)"
+  - name: gps_validador_van
+    description: "Tabela de posições de GPS de todos os validadores da Jaé instalados em vans, incluindo estado do equipamento (Aberto/Fechado), serviço, sentido e veículo associado e temperatura do veículo."
+    columns:
+      - name: modo
+        description: "Tipo de transporte (Ônibus, Van, BRT)"
+      - name: data
+        description: "Data do recebimento da transmissão do GPS (partição)"
+      - name: hora
+        description: "Hora do recebimento da transmissão do GPS"
+      - name: datetime_gps
+        description: "Data e hora do recebimento da transmissão do GPS em GMT-3"
+      - name: datetime_captura
+        description: "Data e hora da captura do dado de GPS em GMT-3"
+      - name: id_operadora
+        description: "Identificador da operadora na tabela cadastro.operadoras"
+      - name: operadora
+        description: "Nome da operadora de transporte (mascarado se for pessoa física)"
+      - name: servico
+        description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...)"
+      - name: id_validador
+        description: "Número de série do validador"
+      - name: id_transmissao_gps
+        description: "Identificador único da tabela de GPS dos validadores"
+      - name: latitude
+        description: "Latitude do validador no momento da transmissão [protegido]"
+        policy_tags:
+          - 'projects/rj-smtr/locations/us/taxonomies/388050497607535163/policyTags/5185403103447535390'
+      - name: longitude
+        description: "Longitude do validador no momento da transmissão [protegido]"
+        policy_tags:
+          - 'projects/rj-smtr/locations/us/taxonomies/388050497607535163/policyTags/5185403103447535390'
+      - name: id_veiculo
+        description: "[EM DESENVOLVIMENTO] Código identificador do veículo (número de ordem)"
+      - name: sentido
+        description: "Sentido da linha"
+      - name: estado_equipamento
+        description: "Validador aberto ou fechado no momento da transmissão"
+      - name: temperatura
+        description: "Temperatura do local, medida pelo sensor do validador (ºC)"
+      - name: versao
+        description: "Código de controle de versão do dado (SHA Github)"
   - name: passageiros_hora
     description: "Tabela de contagem do número de passageiros por hora, criada para uso no painel de bilhetagem. Agrega valores da tabela de transações por: data, hora, modo, consorcio, operadora, servico, sentido e tipo_transacao"
     columns:

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/gps_validador_aux.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/gps_validador_aux.sql
@@ -1,0 +1,33 @@
+{{
+    config(
+        materialized="view"
+    )
+}}
+
+SELECT
+    do.modo,
+    g.data,
+    g.hora,
+    g.data_tracking AS datetime_gps,
+    g.timestamp_captura AS datetime_captura,
+    do.id_operadora,
+    do.operadora,
+    l.nr_linha AS servico,
+    NULL AS id_veiculo,
+    g.numero_serie_equipamento AS id_validador,
+    g.id AS id_transmissao_gps,
+    g.latitude_equipamento AS latitude,
+    g.longitude_equipamento AS longitude,
+    INITCAP(g.sentido_linha) AS sentido,
+    g.estado_equipamento,
+    g.temperatura
+FROM
+    {{ ref("staging_gps_validador") }} g
+LEFT JOIN
+    {{ ref("operadoras") }} AS do
+ON
+    g.codigo_operadora = do.id_operadora_jae
+LEFT JOIN
+    {{ ref("staging_linha") }} AS l
+ON
+    g.codigo_linha_veiculo = l.cd_linha

--- a/models/dashboard_bilhetagem_implantacao_jae/gps_agregado_brt.sql
+++ b/models/dashboard_bilhetagem_implantacao_jae/gps_agregado_brt.sql
@@ -1,0 +1,64 @@
+{{
+  config(
+    materialized="table",
+  )
+}}
+
+WITH gps_agregado AS (
+    SELECT
+        data,
+        servico,
+        id_validador,
+        latitude,
+        longitude,
+        estado_equipamento,
+        primeiro_datetime_gps,
+        ultimo_datetime_gps,
+        TIMESTAMP_DIFF(
+            ultimo_datetime_gps,
+            primeiro_datetime_gps,
+            MINUTE
+        ) + 1 AS qtde_min_entre_a_prim_e_ultima_transmissao,
+        COUNT(*) OVER (PARTITION BY servico, id_validador) AS qtde_registros_gps,
+        COUNT(DISTINCT FORMAT_TIMESTAMP("%F %H:%M", datetime_gps)) OVER (PARTITION BY servico, id_validador) AS qtde_min_distintos_houve_transmissao,
+        SUM(
+            CASE 
+                WHEN latitude != 0 AND longitude != 0 AND latitude IS NOT NULL AND longitude IS NOT NULL THEN 1 
+                ELSE 0 END
+        ) OVER (PARTITION BY servico, id_validador) AS qtde_registros_gps_georreferenciados,
+        ROW_NUMBER() OVER (PARTITION BY servico, id_validador ORDER BY datetime_gps) AS rn
+    FROM
+        (
+            SELECT
+                *,
+                MIN(datetime_gps) OVER (PARTITION BY servico, id_validador) AS primeiro_datetime_gps,
+                MAX(datetime_gps) OVER (PARTITION BY servico, id_validador) AS ultimo_datetime_gps,
+                ROW_NUMBER() OVER (PARTITION BY id_transmissao_gps ORDER BY datetime_captura DESC) AS rn
+            FROM
+                {{ ref("gps_validador") }}
+            WHERE
+                data = current_date("America/Sao_Paulo")
+                AND modo = "BRT"
+        )
+    WHERE
+        rn = 1
+)
+SELECT
+    servico,
+    id_validador,
+    latitude,
+    longitude,
+    data,
+    estado_equipamento,
+    primeiro_datetime_gps,
+    ultimo_datetime_gps,
+    qtde_min_entre_a_prim_e_ultima_transmissao,
+    qtde_min_distintos_houve_transmissao,
+    qtde_registros_gps,
+    qtde_registros_gps_georreferenciados,
+    IFNULL(SAFE_DIVIDE(qtde_registros_gps_georreferenciados, qtde_registros_gps), 0) AS percentual_registros_gps_georreferenciados,
+    IFNULL(SAFE_DIVIDE(qtde_min_distintos_houve_transmissao, qtde_min_entre_a_prim_e_ultima_transmissao), 0) AS percentual_transmissao_a_cada_min
+FROM
+    gps_agregado
+WHERE
+    rn = 1

--- a/models/dashboard_bilhetagem_implantacao_jae/gps_agregado_onibus.sql
+++ b/models/dashboard_bilhetagem_implantacao_jae/gps_agregado_onibus.sql
@@ -38,7 +38,7 @@ WITH gps_agregado AS (
                 {{ ref("gps_validador") }}
             WHERE
                 data = current_date("America/Sao_Paulo")
-                AND modo = "BRT"
+                AND modo = "Ônibus"
         )
     WHERE
         rn = 1

--- a/models/dashboard_bilhetagem_implantacao_jae/gps_agregado_onibus.sql
+++ b/models/dashboard_bilhetagem_implantacao_jae/gps_agregado_onibus.sql
@@ -1,0 +1,64 @@
+{{
+  config(
+    materialized="table",
+  )
+}}
+
+WITH gps_agregado AS (
+    SELECT
+        data,
+        operadora,
+        id_validador,
+        latitude,
+        longitude,
+        estado_equipamento,
+        primeiro_datetime_gps,
+        ultimo_datetime_gps,
+        TIMESTAMP_DIFF(
+            ultimo_datetime_gps,
+            primeiro_datetime_gps,
+            MINUTE
+        ) + 1 AS qtde_min_entre_a_prim_e_ultima_transmissao,
+        COUNT(*) OVER (PARTITION BY operadora, id_validador) AS qtde_registros_gps,
+        COUNT(DISTINCT FORMAT_TIMESTAMP("%F %H:%M", datetime_gps)) OVER (PARTITION BY operadora, id_validador) AS qtde_min_distintos_houve_transmissao,
+        SUM(
+            CASE 
+                WHEN latitude != 0 AND longitude != 0 AND latitude IS NOT NULL AND longitude IS NOT NULL THEN 1 
+                ELSE 0 END
+        ) OVER (PARTITION BY operadora, id_validador) AS qtde_registros_gps_georreferenciados,
+        ROW_NUMBER() OVER (PARTITION BY operadora, id_validador ORDER BY datetime_gps) AS rn
+    FROM
+        (
+            SELECT
+                *,
+                MIN(datetime_gps) OVER (PARTITION BY operadora, id_validador) AS primeiro_datetime_gps,
+                MAX(datetime_gps) OVER (PARTITION BY operadora, id_validador) AS ultimo_datetime_gps,
+                ROW_NUMBER() OVER (PARTITION BY id_transmissao_gps ORDER BY datetime_captura DESC) AS rn
+            FROM
+                {{ ref("gps_validador") }}
+            WHERE
+                data = current_date("America/Sao_Paulo")
+                AND modo = "BRT"
+        )
+    WHERE
+        rn = 1
+)
+SELECT
+    operadora,
+    id_validador,
+    latitude,
+    longitude,
+    data,
+    estado_equipamento,
+    primeiro_datetime_gps,
+    ultimo_datetime_gps,
+    qtde_min_entre_a_prim_e_ultima_transmissao,
+    qtde_min_distintos_houve_transmissao,
+    qtde_registros_gps,
+    qtde_registros_gps_georreferenciados,
+    IFNULL(SAFE_DIVIDE(qtde_registros_gps_georreferenciados, qtde_registros_gps), 0) AS percentual_registros_gps_georreferenciados,
+    IFNULL(SAFE_DIVIDE(qtde_min_distintos_houve_transmissao, qtde_min_entre_a_prim_e_ultima_transmissao), 0) AS percentual_transmissao_a_cada_min
+FROM
+    gps_agregado
+WHERE
+    rn = 1

--- a/models/dashboard_bilhetagem_implantacao_jae/gps_agregado_van.sql
+++ b/models/dashboard_bilhetagem_implantacao_jae/gps_agregado_van.sql
@@ -1,0 +1,59 @@
+{{
+  config(
+    materialized="table",
+  )
+}}
+
+WITH gps_agregado AS (
+    SELECT
+        data,
+        operadora,
+        id_validador,
+        estado_equipamento,
+        primeiro_datetime_gps,
+        ultimo_datetime_gps,
+        TIMESTAMP_DIFF(
+            ultimo_datetime_gps,
+            primeiro_datetime_gps,
+            MINUTE
+        ) + 1 AS qtde_min_entre_a_prim_e_ultima_transmissao,
+        COUNT(*) OVER (PARTITION BY operadora, id_validador) AS qtde_registros_gps,
+        COUNT(DISTINCT FORMAT_TIMESTAMP("%F %H:%M", datetime_gps)) OVER (PARTITION BY operadora, id_validador) AS qtde_min_distintos_houve_transmissao,
+        SUM(
+            CASE 
+                WHEN latitude != 0 AND longitude != 0 AND latitude IS NOT NULL AND longitude IS NOT NULL THEN 1 
+                ELSE 0 END
+        ) OVER (PARTITION BY operadora, id_validador) AS qtde_registros_gps_georreferenciados,
+        ROW_NUMBER() OVER (PARTITION BY operadora, id_validador ORDER BY datetime_gps) AS rn
+    FROM
+        (
+            SELECT
+                *,
+                MIN(datetime_gps) OVER (PARTITION BY operadora, id_validador) AS primeiro_datetime_gps,
+                MAX(datetime_gps) OVER (PARTITION BY operadora, id_validador) AS ultimo_datetime_gps,
+                ROW_NUMBER() OVER (PARTITION BY id_transmissao_gps ORDER BY datetime_captura DESC) AS rn
+            FROM
+                {{ ref("gps_validador_van") }}
+            WHERE
+                data = current_date("America/Sao_Paulo")
+        )
+    WHERE
+        rn = 1
+)
+SELECT
+    operadora,
+    id_validador,
+    data,
+    estado_equipamento,
+    primeiro_datetime_gps,
+    ultimo_datetime_gps,
+    qtde_min_entre_a_prim_e_ultima_transmissao,
+    qtde_min_distintos_houve_transmissao,
+    qtde_registros_gps,
+    qtde_registros_gps_georreferenciados,
+    IFNULL(SAFE_DIVIDE(qtde_registros_gps_georreferenciados, qtde_registros_gps), 0) AS percentual_registros_gps_georreferenciados,
+    IFNULL(SAFE_DIVIDE(qtde_min_distintos_houve_transmissao, qtde_min_entre_a_prim_e_ultima_transmissao), 0) AS percentual_transmissao_a_cada_min
+FROM
+    gps_agregado
+WHERE
+    rn = 1

--- a/models/dashboard_bilhetagem_implantacao_jae/gps_agregado_vlt.sql
+++ b/models/dashboard_bilhetagem_implantacao_jae/gps_agregado_vlt.sql
@@ -1,0 +1,64 @@
+{{
+  config(
+    materialized="table",
+  )
+}}
+
+WITH gps_agregado AS (
+    SELECT
+        data,
+        servico,
+        id_validador,
+        latitude,
+        longitude,
+        estado_equipamento,
+        primeiro_datetime_gps,
+        ultimo_datetime_gps,
+        TIMESTAMP_DIFF(
+            ultimo_datetime_gps,
+            primeiro_datetime_gps,
+            MINUTE
+        ) + 1 AS qtde_min_entre_a_prim_e_ultima_transmissao,
+        COUNT(*) OVER (PARTITION BY servico, id_validador) AS qtde_registros_gps,
+        COUNT(DISTINCT FORMAT_TIMESTAMP("%F %H:%M", datetime_gps)) OVER (PARTITION BY servico, id_validador) AS qtde_min_distintos_houve_transmissao,
+        SUM(
+            CASE 
+                WHEN latitude != 0 AND longitude != 0 AND latitude IS NOT NULL AND longitude IS NOT NULL THEN 1 
+                ELSE 0 END
+        ) OVER (PARTITION BY servico, id_validador) AS qtde_registros_gps_georreferenciados,
+        ROW_NUMBER() OVER (PARTITION BY servico, id_validador ORDER BY datetime_gps) AS rn
+    FROM
+        (
+            SELECT
+                *,
+                MIN(datetime_gps) OVER (PARTITION BY servico, id_validador) AS primeiro_datetime_gps,
+                MAX(datetime_gps) OVER (PARTITION BY servico, id_validador) AS ultimo_datetime_gps,
+                ROW_NUMBER() OVER (PARTITION BY id_transmissao_gps ORDER BY datetime_captura DESC) AS rn
+            FROM
+                {{ ref("gps_validador") }}
+            WHERE
+                data = current_date("America/Sao_Paulo")
+                AND modo = "VLT"
+        )
+    WHERE
+        rn = 1
+)
+SELECT
+    servico,
+    id_validador,
+    latitude,
+    longitude,
+    data,
+    estado_equipamento,
+    primeiro_datetime_gps,
+    ultimo_datetime_gps,
+    qtde_min_entre_a_prim_e_ultima_transmissao,
+    qtde_min_distintos_houve_transmissao,
+    qtde_registros_gps,
+    qtde_registros_gps_georreferenciados,
+    IFNULL(SAFE_DIVIDE(qtde_registros_gps_georreferenciados, qtde_registros_gps), 0) AS percentual_registros_gps_georreferenciados,
+    IFNULL(SAFE_DIVIDE(qtde_min_distintos_houve_transmissao, qtde_min_entre_a_prim_e_ultima_transmissao), 0) AS percentual_transmissao_a_cada_min
+FROM
+    gps_agregado
+WHERE
+    rn = 1


### PR DESCRIPTION
## Changelog
- Separa a tabela de GPS validador em 2 tabelas, uma só para van e outra para os demais modos
- Cria tabelas agregadas para o PBI
