### PR TITLE
Bilhetagem - Adiciona rateio na tabela de ordem de pagamento / ajustes na validação

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -203,7 +203,7 @@ models:
       +schema: br_rj_riodejaneiro_bilhetagem
     br_rj_riodejaneiro_bilhetagem_staging:
       +materialized: view
-      +schema: br_rj_riodejaneiro_bilhetagem_staging
+      +schema: br_rj_riodejaneiro_bilhetagem_staging_dbt
     dashboard_bilhetagem_implantacao_jae:
       +materialized: table
       +schema: dashboard_bilhetagem_implantacao_jae

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -203,7 +203,7 @@ models:
       +schema: br_rj_riodejaneiro_bilhetagem
     br_rj_riodejaneiro_bilhetagem_staging:
       +materialized: view
-      +schema: br_rj_riodejaneiro_bilhetagem_staging_dbt
+      +schema: br_rj_riodejaneiro_bilhetagem_staging
     dashboard_bilhetagem_implantacao_jae:
       +materialized: table
       +schema: dashboard_bilhetagem_implantacao_jae

--- a/models/br_rj_riodejaneiro_bilhetagem/ordem_pagamento.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/ordem_pagamento.sql
@@ -10,49 +10,49 @@
   )
 }}
 
-WITH servico_motorista AS (
-    SELECT
-        * EXCEPT(rn)
-    FROM
-    (
-        SELECT
-            id_servico,
-            dt_fechamento,
-            nr_logico_midia,
-            cd_linha,
-            cd_operadora,
-            ROW_NUMBER() OVER (PARTITION BY id_servico, nr_logico_midia ORDER BY timestamp_captura DESC) AS rn
-        FROM
-            {{ ref("staging_servico_motorista") }}
-        {% if is_incremental() %}
-            WHERE
-                DATE(data) BETWEEN DATE_SUB(DATE("{{var('date_range_start')}}"), INTERVAL 1 DAY) AND DATE("{{var('date_range_end')}}")
-        {% endif %}  
-    )   
-),
-transacao AS (
+-- WITH servico_motorista AS (
+--     SELECT
+--         * EXCEPT(rn)
+--     FROM
+--     (
+--         SELECT
+--             id_servico,
+--             dt_fechamento,
+--             nr_logico_midia,
+--             cd_linha,
+--             cd_operadora,
+--             ROW_NUMBER() OVER (PARTITION BY id_servico, nr_logico_midia ORDER BY timestamp_captura DESC) AS rn
+--         FROM
+--             {{ ref("staging_servico_motorista") }}
+--         {% if is_incremental() %}
+--             WHERE
+--                 DATE(data) BETWEEN DATE_SUB(DATE("{{var('date_range_start')}}"), INTERVAL 1 DAY) AND DATE("{{var('date_range_end')}}")
+--         {% endif %}  
+--     )   
+-- ),
+WITH transacao AS (
     SELECT
         t.id,
         t.timestamp_captura,
-        DATE(data_processamento) AS data_processamento,
-        data_processamento AS datetime_processamento,
+        DATE(t.data_processamento) AS data_processamento,
+        t.data_processamento AS datetime_processamento,
         t.cd_linha,
         t.cd_operadora,
         t.valor_transacao,
         t.tipo_transacao,
         t.id_tipo_modal,
         t.cd_consorcio,
-        sm.dt_fechamento AS datetime_fechamento_servico,
-        sm.cd_linha AS cd_linha_servico,
-        sm.cd_operadora AS cd_operadora_servico,
+        -- sm.dt_fechamento AS datetime_fechamento_servico,
+        -- sm.cd_linha AS cd_linha_servico,
+        -- sm.cd_operadora AS cd_operadora_servico,
         t.id_servico
     FROM
         {{ ref("staging_transacao") }} t
-    LEFT JOIN
-        servico_motorista sm
-    ON
-        sm.id_servico = t.id_servico
-        AND sm.nr_logico_midia = t.nr_logico_midia_operador
+    -- LEFT JOIN
+    --     servico_motorista sm
+    -- ON
+    --     sm.id_servico = t.id_servico
+    --     AND sm.nr_logico_midia = t.nr_logico_midia_operador
     WHERE
         {% if is_incremental() %}
             DATE(t.data) BETWEEN DATE_SUB(DATE("{{var('date_range_start')}}"), INTERVAL 1 DAY) AND DATE_ADD(DATE("{{var('date_range_end')}}"), INTERVAL 1 DAY)
@@ -92,7 +92,7 @@ transacao_agg AS (
     WHERE
         -- Remove dados com data de ordem de pagamento maiores que a execução do modelo
         {% if is_incremental() %}
-            t.data_ordem DATE("{{var('date_range_end')}}")
+            t.data_ordem <= DATE("{{var('date_range_end')}}")
         {% else %}
             t.data_ordem <= CURRENT_DATE("America/Sao_Paulo")
         {% endif %}

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_linha_sem_ressarcimento.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_linha_sem_ressarcimento.sql
@@ -11,7 +11,7 @@ WITH linha_sem_ressarcimento AS (
     DATETIME(PARSE_TIMESTAMP('%Y-%m-%d %H:%M:%S%Ez', timestamp_captura), "America/Sao_Paulo") AS timestamp_captura,
     DATETIME(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*S%Ez', SAFE_CAST(JSON_VALUE(content, '$.dt_inclusao') AS STRING)), 'America/Sao_Paulo') AS dt_inclusao
   FROM
-    {{ source('br_rj_riodejaneiro_bilhetagem_staging_dev', 'linha_sem_ressarcimento') }}
+    {{ source('br_rj_riodejaneiro_bilhetagem_staging', 'linha_sem_ressarcimento') }}
 )
 SELECT 
   * EXCEPT(rn)

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_linha_sem_ressarcimento.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_linha_sem_ressarcimento.sql
@@ -1,0 +1,27 @@
+{{
+  config(
+    alias='linha_sem_ressarcimento',
+  )
+}}
+
+WITH linha_sem_ressarcimento AS (
+  SELECT
+    data,
+    SAFE_CAST(id_linha AS STRING) AS id_linha,
+    DATETIME(PARSE_TIMESTAMP('%Y-%m-%d %H:%M:%S%Ez', timestamp_captura), "America/Sao_Paulo") AS timestamp_captura,
+    DATETIME(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*S%Ez', SAFE_CAST(JSON_VALUE(content, '$.dt_inclusao') AS STRING)), 'America/Sao_Paulo') AS dt_inclusao
+  FROM
+    {{ source('br_rj_riodejaneiro_bilhetagem_staging_dev', 'linha_sem_ressarcimento') }}
+)
+SELECT 
+  * EXCEPT(rn)
+FROM
+(
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id_linha ORDER BY timestamp_captura DESC) AS rn
+  FROM
+    linha_sem_ressarcimento
+)
+WHERE
+  rn = 1

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_rateio.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_rateio.sql
@@ -43,7 +43,7 @@ WITH ordem_rateio AS (
         SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t4') AS FLOAT64) AS valor_rateio_compensacao_debito_t4,
         SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_total') AS FLOAT64) AS valor_rateio_compensacao_debito_total
   FROM
-    {{ source('br_rj_riodejaneiro_bilhetagem_staging_dev', 'ordem_rateio') }}
+    {{ source('br_rj_riodejaneiro_bilhetagem_staging', 'ordem_rateio') }}
 )
 SELECT 
   * EXCEPT(rn)

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_rateio.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_rateio.sql
@@ -1,0 +1,59 @@
+{{
+  config(
+    alias='ordem_rateio',
+  )
+}}
+
+WITH ordem_rateio AS (
+  SELECT
+    data,
+        SAFE_CAST(id AS STRING) AS id,
+        timestamp_captura,
+        DATETIME(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*S%Ez', SAFE_CAST(JSON_VALUE(content, '$.data_inclusao') AS STRING)), 'America/Sao_Paulo') AS data_inclusao,
+        PARSE_DATE('%Y-%m-%d', SAFE_CAST(JSON_VALUE(content, '$.data_ordem') AS STRING)) AS data_ordem,
+        SAFE_CAST(JSON_VALUE(content, '$.id_consorcio') AS STRING) AS id_consorcio,
+        SAFE_CAST(JSON_VALUE(content, '$.id_linha') AS STRING) AS id_linha,
+        SAFE_CAST(JSON_VALUE(content, '$.id_operadora') AS STRING) AS id_operadora,
+        SAFE_CAST(JSON_VALUE(content, '$.id_ordem_pagamento') AS STRING) AS id_ordem_pagamento,
+        SAFE_CAST(JSON_VALUE(content, '$.id_ordem_pagamento_consorcio') AS STRING) AS id_ordem_pagamento_consorcio,
+        SAFE_CAST(JSON_VALUE(content, '$.id_ordem_pagamento_consorcio_operadora') AS STRING) AS id_ordem_pagamento_consorcio_operadora,
+        SAFE_CAST(JSON_VALUE(content, '$.id_status_ordem') AS STRING) AS id_status_ordem,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_credito_t0') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_credito_t0,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_credito_t1') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_credito_t1,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_credito_t2') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_credito_t2,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_credito_t3') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_credito_t3,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_credito_t4') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_credito_t4,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_credito_total') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_credito_total,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_debito_t0') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_debito_t0,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_debito_t1') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_debito_t1,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_debito_t2') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_debito_t2,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_debito_t3') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_debito_t3,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_debito_t4') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_debito_t4,
+        SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_debito_total') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_debito_total,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t0') AS FLOAT64) AS valor_rateio_compensacao_credito_t0,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t1') AS FLOAT64) AS valor_rateio_compensacao_credito_t1,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t2') AS FLOAT64) AS valor_rateio_compensacao_credito_t2,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t3') AS FLOAT64) AS valor_rateio_compensacao_credito_t3,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t4') AS FLOAT64) AS valor_rateio_compensacao_credito_t4,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_total') AS FLOAT64) AS valor_rateio_compensacao_credito_total,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t0') AS FLOAT64) AS valor_rateio_compensacao_debito_t0,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t1') AS FLOAT64) AS valor_rateio_compensacao_debito_t1,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t2') AS FLOAT64) AS valor_rateio_compensacao_debito_t2,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t3') AS FLOAT64) AS valor_rateio_compensacao_debito_t3,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t4') AS FLOAT64) AS valor_rateio_compensacao_debito_t4,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_total') AS FLOAT64) AS valor_rateio_compensacao_debito_total
+  FROM
+    {{ source('br_rj_riodejaneiro_bilhetagem_staging_dev', 'ordem_rateio') }}
+)
+SELECT 
+  * EXCEPT(rn)
+FROM
+(
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY timestamp_captura DESC) AS rn
+  FROM
+    ordem_rateio
+)
+WHERE
+  rn = 1

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_servico_motorista.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_servico_motorista.sql
@@ -4,7 +4,6 @@
   )
 }}
 
--- WITH servico_motorista AS (
 SELECT
   data,
   SAFE_CAST(NR_LOGICO_MIDIA AS STRING) AS nr_logico_midia,
@@ -21,17 +20,4 @@ SELECT
   SAFE_CAST(JSON_VALUE(content, '$.TP_GERACAO') AS STRING) AS tp_geracao,
   SAFE_CAST(JSON_VALUE(content, '$.VL_TARIFA_LINHA') AS FLOAT64) AS vl_tarifa_linha
 FROM
-  {{ source('br_rj_riodejaneiro_bilhetagem_staging_dev', 'servico_motorista') }}
--- )
--- SELECT 
---   * EXCEPT(rn)
--- FROM
--- (
---   SELECT
---     *,
---     ROW_NUMBER() OVER (PARTITION BY NR_LOGICO_MIDIA, ID_SERVICO ORDER BY timestamp_captura DESC) AS rn
---   FROM
---     servico_motorista
--- )
--- WHERE
---   rn = 1
+  {{ source('br_rj_riodejaneiro_bilhetagem_staging', 'servico_motorista') }}

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_servico_motorista.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_servico_motorista.sql
@@ -1,0 +1,37 @@
+{{
+  config(
+    alias='servico_motorista',
+  )
+}}
+
+-- WITH servico_motorista AS (
+SELECT
+  data,
+  SAFE_CAST(NR_LOGICO_MIDIA AS STRING) AS nr_logico_midia,
+  SAFE_CAST(ID_SERVICO AS STRING) AS id_servico,
+  DATETIME(PARSE_TIMESTAMP('%Y-%m-%d %H:%M:%S%Ez', timestamp_captura), "America/Sao_Paulo") AS timestamp_captura,
+  SAFE_CAST(JSON_VALUE(content, '$.CD_LINHA') AS STRING) AS cd_linha,
+  SAFE_CAST(JSON_VALUE(content, '$.CD_OPERADORA') AS STRING) AS cd_operadora,
+  SAFE_CAST(JSON_VALUE(content, '$.CD_STATUS') AS STRING) AS cd_status,
+  DATETIME(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%S%Ez', SAFE_CAST(JSON_VALUE(content, '$.DT_ABERTURA') AS STRING)), 'America/Sao_Paulo') AS dt_abertura,
+  DATETIME(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%S%Ez', SAFE_CAST(JSON_VALUE(content, '$.DT_FECHAMENTO') AS STRING)), 'America/Sao_Paulo') AS dt_fechamento,
+  SAFE_CAST(JSON_VALUE(content, '$.ID_VEICULO') AS STRING) AS id_veiculo,
+  SAFE_CAST(JSON_VALUE(content, '$.NR_LOGICO_MIDIA_FECHAMENTO') AS STRING) AS nr_logico_midia_fechamento,
+  SAFE_CAST(JSON_VALUE(content, '$.SN_DEVICE') AS STRING) AS sn_device,
+  SAFE_CAST(JSON_VALUE(content, '$.TP_GERACAO') AS STRING) AS tp_geracao,
+  SAFE_CAST(JSON_VALUE(content, '$.VL_TARIFA_LINHA') AS FLOAT64) AS vl_tarifa_linha
+FROM
+  {{ source('br_rj_riodejaneiro_bilhetagem_staging_dev', 'servico_motorista') }}
+-- )
+-- SELECT 
+--   * EXCEPT(rn)
+-- FROM
+-- (
+--   SELECT
+--     *,
+--     ROW_NUMBER() OVER (PARTITION BY NR_LOGICO_MIDIA, ID_SERVICO ORDER BY timestamp_captura DESC) AS rn
+--   FROM
+--     servico_motorista
+-- )
+-- WHERE
+--   rn = 1

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -20,6 +20,16 @@ sources:
       - name: tipo_modal
       - name: gps_validador
       - name: gratuidade
+      - name: ordem_rateio
+      - name: servico_motorista
+  
+  - name: br_rj_riodejaneiro_bilhetagem_staging_dev
+    database: rj-smtr-dev
+    schema: br_rj_riodejaneiro_bilhetagem_staging
+
+    tables:
+      - name: ordem_rateio
+      - name: servico_motorista
 
   - name: br_rj_riodejaneiro_gtfs_staging
     database: rj-smtr-staging

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -22,6 +22,7 @@ sources:
       - name: gratuidade
       - name: ordem_rateio
       - name: servico_motorista
+      - name: linha_sem_ressarcimento
   
   - name: br_rj_riodejaneiro_bilhetagem_staging_dev
     database: rj-smtr-dev
@@ -30,6 +31,7 @@ sources:
     tables:
       - name: ordem_rateio
       - name: servico_motorista
+      - name: linha_sem_ressarcimento
 
   - name: br_rj_riodejaneiro_gtfs_staging
     database: rj-smtr-staging

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -23,15 +23,6 @@ sources:
       - name: ordem_rateio
       - name: servico_motorista
       - name: linha_sem_ressarcimento
-  
-  - name: br_rj_riodejaneiro_bilhetagem_staging_dev
-    database: rj-smtr-dev
-    schema: br_rj_riodejaneiro_bilhetagem_staging
-
-    tables:
-      - name: ordem_rateio
-      - name: servico_motorista
-      - name: linha_sem_ressarcimento
 
   - name: br_rj_riodejaneiro_gtfs_staging
     database: rj-smtr-staging


### PR DESCRIPTION
## Changelog
- bilhetagem.ordem_pagamento:
  - feat: Adiciona informações de rateio crédito e débito
  - fix: Remove quantidades de rateio crédito e débito da soma do total de transações
  - fix: Filtra transações de teste com base na tabela linha_sem_ressarcimento
- cria modelos:
  - bilhetagem_staging.linha_sem_ressarcimento_staging
  - bilhetagem_staging.ordem_rateio_staging
  - bilhetagem_staging.servico_motorista_staging
