### PR TITLE
Ajusta a descricao das tabelas de bilhetagem

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -219,7 +219,7 @@ models:
       +schema: br_rj_riodejaneiro_bilhetagem
     br_rj_riodejaneiro_bilhetagem_staging:
       +materialized: view
-      +schema: br_rj_riodejaneiro_bilhetagem_staging_dbt
+      +schema: br_rj_riodejaneiro_bilhetagem_staging
     dashboard_bilhetagem_implantacao_jae:
       +materialized: table
       +schema: dashboard_bilhetagem_implantacao_jae

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -219,7 +219,7 @@ models:
       +schema: br_rj_riodejaneiro_bilhetagem
     br_rj_riodejaneiro_bilhetagem_staging:
       +materialized: view
-      +schema: br_rj_riodejaneiro_bilhetagem_staging
+      +schema: br_rj_riodejaneiro_bilhetagem_staging_dbt
     dashboard_bilhetagem_implantacao_jae:
       +materialized: table
       +schema: dashboard_bilhetagem_implantacao_jae

--- a/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - bilhetagem
 
+## [1.0.1] - 2024-04-11
+
+### Adicionado 
+- Adicionada descrições das colunas das tabelas: `ordem_pagamento_consorcio_dia`, `ordem_pagamento_consorcio_operador_dia`, `ordem_pagamento_dia`,`transacao_riocard`
+
 ## [1.0.0] - 2024-04-05
 
 ### Adicionado

--- a/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog - bilhetagem
 
-## [1.0.1] - 2024-04-15
+## [1.0.1] - 2024-04-16
 
 ### Adicionado 
 - Adicionada descrições das colunas das tabelas: `ordem_pagamento_consorcio_dia`, `ordem_pagamento_consorcio_operador_dia`, `ordem_pagamento_dia`,`transacao_riocard`
+- Adicionada a descrição da coluna intervalo_integracao na tabela `integracao`
+
+### Corrigido
+- deletada a tabela ordem_pagamento do schema
 
 ## [1.0.0] - 2024-04-05
 

--- a/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - bilhetagem
 
-## [1.0.1] - 2024-04-11
+## [1.0.1] - 2024-04-15
 
 ### Adicionado 
 - Adicionada descrições das colunas das tabelas: `ordem_pagamento_consorcio_dia`, `ordem_pagamento_consorcio_operador_dia`, `ordem_pagamento_dia`,`transacao_riocard`

--- a/models/br_rj_riodejaneiro_bilhetagem/schema.yml
+++ b/models/br_rj_riodejaneiro_bilhetagem/schema.yml
@@ -62,63 +62,6 @@ models:
         description: "Valor debitado na transação atual (R$)"
       - name: versao
         description: "Código de controle de versão do dado (SHA Github)"
-  - name: ordem_pagamento
-    description: "Tabela de ordem de pagamento do banco de dados de dados da Jaé"
-    columns:
-      - name: data_ordem
-        description: "Data da ordem de pagamento (partição)"
-      - name: data_pagamento
-        description: "Data de pagamento da ordem"
-      - name: id_consorcio
-        description: "Identificador do consórcio na tabela cadastro.consorcios"
-      - name: id_operadora
-        description: "Identificador da operadora na tabela cadastro.operadoras"
-      - name: servico
-        description: "Nome curto da linha operada com variação de serviço (ex: 010, 011SN, ...)"
-      - name: id_ordem_pagamento
-        description: "Identificador da ordem pagamento no banco de dados da Jaé"
-      - name: id_ordem_ressarcimento
-        description: "Identificador da ordem ressarcimento no banco de dados da Jaé"
-      - name: quantidade_transacao_debito
-        description: "Quantidade de transações feitas na modalidade débito"
-      - name: valor_debito
-        description: "Valor total das transações feitas na modalidade débito (R$)"
-      - name: quantidade_transacao_especie
-        description: "Quantidade de transações feitas em espécie"
-      - name: valor_especie
-        description: "Valor total das transações feitas em espécie (R$)"
-      - name: quantidade_transacao_gratuidade
-        description: "Quantidade de transações feitas com gratuidade"
-      - name: valor_gratuidade
-        description: "Valor total das transações feitas com gratuidade (R$)"
-      - name: quantidade_transacao_integracao
-        description: "Quantidade de transações feitas com integração"
-      - name: valor_integracao
-        description: "Valor total das transações feitas com integração (R$)"
-       - name: quantidade_transacao_rateio_credito
-        description: "Quantidade total de transações consideradas no crédito da repartição tarifária"
-      - name: valor_rateio_credito
-        description: "Valor total creditado em decorrência da repartição tarifária (R$)"
-      - name: quantidade_transacao_rateio_debito
-        description: "Quantidade total de transações consideradas no débito da repartição tarifária"
-      - name: valor_rateio_debito
-        description: "Valor total debitado em decorrência da repartição tarifária (R$)"
-      - name: quantidade_total_transacao
-        description: "Quantidade total de transações realizadas"
-      - name: valor_total_transacao_bruto
-        description: "Valor total das transações realizadas (R$)"
-      - name: valor_desconto_taxa
-        description: "Valor da taxa descontado do valor total (R$)"
-      - name: valor_total_transacao_liquido
-        description: "Valor total das transações menos o valor_desconto_taxa (R$)"
-      - name: quantidade_total_transacao_captura
-        description: "Quantidade total de transações calculada pela captura de transações"
-      - name: valor_total_transacao_captura
-        description: "Valor total das transações realizadas calculada pela captura de transações (R$)"
-      - name: indicador_ordem_valida
-        description: "Indicador de validação da ordem de pagamento i.e. se a quantidade e valor total informados são encontrados na captura de transações individuais"
-      - name: versao
-        description: "Código de controle de versão do dado (SHA Github)"
   - name: integracao
     description: "Tabela de integrações realizadas entre modos do sistema de transporte municipal, contendo os valores da repartição tarifária (quando houver). [Dados em fase de teste]"
     columns:
@@ -133,7 +76,7 @@ models:
       - name: datetime_transacao
         description: "Data e hora da integração em GMT-3"
       - name: intervalo_integracao
-        description: "Tempo de intervalo da integração em minutos"
+        description: "Tempo entre a perna atual da integração e a anterior em minutos"
       - name: id_integracao
         description: "Identificador único da integração"
       - name: sequencia_integracao

--- a/models/br_rj_riodejaneiro_bilhetagem/schema.yml
+++ b/models/br_rj_riodejaneiro_bilhetagem/schema.yml
@@ -95,14 +95,14 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-      - name: quantidade_transacao_rateio_credito
-        description: ""
+       - name: quantidade_transacao_rateio_credito
+        description: "Quantidade total de transações consideradas no crédito da repartição tarifária"
       - name: valor_rateio_credito
-        description: ""
+        description: "Valor total creditado em decorrência da repartição tarifária (R$)"
       - name: quantidade_transacao_rateio_debito
-        description: ""
+        description: "Quantidade total de transações consideradas no débito da repartição tarifária"
       - name: valor_rateio_debito
-        description: ""
+        description: "Valor total debitado em decorrência da repartição tarifária (R$)"
       - name: quantidade_total_transacao
         description: "Quantidade total de transações realizadas"
       - name: valor_total_transacao_bruto
@@ -306,7 +306,7 @@ models:
       - name: valor
         description: "Valor"
   - name: ordem_pagamento_consorcio_dia
-    description:
+    description: "Tabela com os valores totais de pagamento da Jaé agregados por consorcio e dia"
     columns: 
       - name: data_ordem
         description: "Data da ordem de pagamento (partição)"
@@ -332,23 +332,22 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-      - name: quantidade_transacao_rateio_credito
-        description: ""
+       - name: quantidade_transacao_rateio_credito
+        description: "Quantidade total de transações consideradas no crédito da repartição tarifária"
       - name: valor_rateio_credito
-        description: ""
+        description: "Valor total creditado em decorrência da repartição tarifária (R$)"
       - name: quantidade_transacao_rateio_debito
-        description: ""
+        description: "Quantidade total de transações consideradas no débito da repartição tarifária"
       - name: valor_rateio_debito
-        description: ""
+        description: "Valor total debitado em decorrência da repartição tarifária (R$)"
       - name: valor_total_transacao_bruto
         description: "Valor total das transações realizadas (R$)"
       - name: valor_desconto_taxa
         description: "Valor da taxa descontado do valor total (R$)"
       - name: versao
         description: "Código de controle de versão do dado (SHA Github)"
-
   - name: ordem_pagamento_consorcio_operador_dia
-    description:
+    description: "Tabela com os valores totais de pagamento da Jaé agregados por consorcio, operador e dia"
     columns:
       - name: data_ordem
         description: "Data da ordem de pagamento (partição)"
@@ -356,6 +355,10 @@ models:
         description: "Identificador do consórcio na tabela cadastro.consorcios"
       - name: consorcio
         description: "Nome do consórcio"
+      - name: id_operadora
+        description: "Identificador da operadora na tabela cadastro.operadoras"
+      - name: operadora
+        description: "Nome da operadora de transporte (mascarado se for pessoa física)"
       - name: id_ordem_pagamento
         description: "Identificador da ordem pagamento no banco de dados da Jaé"
       - name: quantidade_transacao_debito
@@ -374,14 +377,14 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-      - name: quantidade_transacao_rateio_credito
-        description: ""
+       - name: quantidade_transacao_rateio_credito
+        description: "Quantidade total de transações consideradas no crédito da repartição tarifária"
       - name: valor_rateio_credito
-        description: ""
+        description: "Valor total creditado em decorrência da repartição tarifária (R$)"
       - name: quantidade_transacao_rateio_debito
-        description: ""
+        description: "Quantidade total de transações consideradas no débito da repartição tarifária"
       - name: valor_rateio_debito
-        description: ""
+        description: "Valor total debitado em decorrência da repartição tarifária (R$)"
       - name: valor_total_transacao_bruto
         description: "Valor total das transações realizadas (R$)"
       - name: valor_desconto_taxa
@@ -389,7 +392,7 @@ models:
       - name: versao
         description: "Código de controle de versão do dado (SHA Github)"
   - name: ordem_pagamento_dia
-    description:
+    description: "Tabela com os valores totais de pagamento da Jaé agregados por dia"
     columns:
       - name: data_ordem
         description: "Data da ordem de pagamento (partição)"
@@ -411,14 +414,14 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-      - name: quantidade_transacao_rateio_credito
-        description: ""
+       - name: quantidade_transacao_rateio_credito
+        description: "Quantidade total de transações consideradas no crédito da repartição tarifária"
       - name: valor_rateio_credito
-        description: ""
+        description: "Valor total creditado em decorrência da repartição tarifária (R$)"
       - name: quantidade_transacao_rateio_debito
-        description: ""
+        description: "Quantidade total de transações consideradas no débito da repartição tarifária"
       - name: valor_rateio_debito
-        description: ""
+        description: "Valor total debitado em decorrência da repartição tarifária (R$)"
       - name: valor_total_transacao_bruto
         description: "Valor total das transações realizadas (R$)"
       - name: valor_desconto_taxa
@@ -428,7 +431,7 @@ models:
       - name: versao
         description: "Código de controle de versão do dado (SHA Github)"
   - name: ordem_pagamento_servico_operador_dia
-    descriptions:
+    descriptions: "Tabela com os valores totais de pagamento da Jaé agregados por serviço, operador e dia"
     columns:
       - name: data_ordem
         description: "Data da ordem de pagamento (partição)"
@@ -462,14 +465,14 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-      - name: quantidade_transacao_rateio_credito
-        description: ""
+       - name: quantidade_transacao_rateio_credito
+        description: "Quantidade total de transações consideradas no crédito da repartição tarifária"
       - name: valor_rateio_credito
-        description: ""
+        description: "Valor total creditado em decorrência da repartição tarifária (R$)"
       - name: quantidade_transacao_rateio_debito
-        description: ""
+        description: "Quantidade total de transações consideradas no débito da repartição tarifária"
       - name: valor_rateio_debito
-        description: ""
+        description: "Valor total debitado em decorrência da repartição tarifária (R$)"
       - name: quantidade_total_transacao
         description: "Quantidade total de transações realizadas"
       - name: valor_total_transacao_bruto
@@ -487,6 +490,7 @@ models:
       - name: versao
         description: "Código de controle de versão do dado (SHA Github)"
   - name: transacao_riocard
+    description: "Tabela com as transações feitas com RioCard que foram registradas pelo validador da Jaé."
     columns:
       - name: data
         description: "Data da transação (partição)"

--- a/models/br_rj_riodejaneiro_bilhetagem/schema.yml
+++ b/models/br_rj_riodejaneiro_bilhetagem/schema.yml
@@ -132,6 +132,8 @@ models:
         description: "Data e hora da captura da integração em GMT-3"
       - name: datetime_transacao
         description: "Data e hora da transação em GMT-3"
+      - name: intervalo_integracao
+        description: "Tempo de intervalo da integração em minutos"
       - name: id_integracao
         description: "Identificador único da integração"
       - name: sequencia_integracao
@@ -303,4 +305,135 @@ models:
         description: "Nome da coluna"
       - name: valor
         description: "Valor"
-        
+  - name: ordem_pagamento_consorcio_dia
+    description:
+    columns: 
+      - name: data_ordem
+        description: "Data da ordem de pagamento (partição)"
+      - name: id_consorcio
+        description: "Identificador do consórcio na tabela cadastro.consorcios"
+      - name: consorcio
+        description: "Nome do consórcio"
+      - name: id_ordem_pagamento
+        description: "Identificador da ordem pagamento no banco de dados da Jaé"
+      - name: quantidade_transacao_debito
+        description: "Quantidade de transações feitas na modalidade débito"
+      - name: valor_debito
+        description: "Valor total das transações feitas na modalidade débito (R$)"
+      - name: quantidade_transacao_especie
+        description: "Quantidade de transações feitas em espécie"
+      - name: valor_especie
+        description: "Valor total das transações feitas em espécie (R$)"
+      - name: quantidade_transacao_gratuidade
+        description: "Quantidade de transações feitas com gratuidade"
+      - name: valor_gratuidade
+        description: "Valor total das transações feitas com gratuidade (R$)"
+      - name: quantidade_transacao_integracao
+        description: "Quantidade de transações feitas com integração"
+      - name: valor_integracao
+        description: "Valor total das transações feitas com integração (R$)"
+        # faltando preencher #
+      - name: quantidade_transacao_rateio_credito
+        description:
+      - name: valor_rateio_credito
+        description:
+      - name: quantidade_transacao_rateio_debito
+        description:
+      - name: valor_rateio_debito
+        description:
+        # ----------------- #
+      - name: valor_total_transacao_bruto
+        description: "Valor total das transações realizadas (R$)"
+      - name: valor_desconto_taxa
+        description: "Valor da taxa descontado do valor total (R$)"
+      - name: versao
+        description: "Código de controle de versão do dado (SHA Github)"
+
+  - name: ordem_pagamento_consorcio_operador_dia
+    description:
+    columns:
+      - name: data_ordem
+        description: "Data da ordem de pagamento (partição)"
+      - name: id_consorcio
+        description: "Identificador do consórcio na tabela cadastro.consorcios"
+      - name: consorcio
+        description: "Nome do consórcio"
+      - name: id_ordem_pagamento
+        description: "Identificador da ordem pagamento no banco de dados da Jaé"
+      - name: quantidade_transacao_debito
+        description: "Quantidade de transações feitas na modalidade débito"
+      - name: valor_debito
+        description: "Valor total das transações feitas na modalidade débito (R$)"
+      - name: quantidade_transacao_especie
+        description: "Quantidade de transações feitas em espécie"
+      - name: valor_especie
+        description: "Valor total das transações feitas em espécie (R$)"
+      - name: quantidade_transacao_gratuidade
+        description: "Quantidade de transações feitas com gratuidade"
+      - name: valor_gratuidade
+        description: "Valor total das transações feitas com gratuidade (R$)"
+      - name: quantidade_transacao_integracao
+        description: "Quantidade de transações feitas com integração"
+      - name: valor_integracao
+        description: "Valor total das transações feitas com integração (R$)"
+        # faltando preencher #
+      - name: quantidade_transacao_rateio_credito
+        description:
+      - name: valor_rateio_credito
+        description:
+      - name: quantidade_transacao_rateio_debito
+        description:
+      - name: valor_rateio_debito
+        description:
+        # ----------------- #
+      - name: valor_total_transacao_bruto
+        description: "Valor total das transações realizadas (R$)"
+      - name: valor_desconto_taxa
+        description: "Valor da taxa descontado do valor total (R$)"
+      - name: versao
+        description: "Código de controle de versão do dado (SHA Github)"
+  - name: ordem_pagamento_dia
+    description:
+    columns:
+      - name: data_ordem
+        description: "Data da ordem de pagamento (partição)"
+      - name: id_ordem_pagamento
+        description: "Identificador da ordem pagamento no banco de dados da Jaé"
+      - name: quantidade_transacao_debito
+        description: "Quantidade de transações feitas na modalidade débito"
+      - name: valor_debito
+        description: "Valor total das transações feitas na modalidade débito (R$)"
+      - name: quantidade_transacao_especie
+        description: "Quantidade de transações feitas em espécie"
+      - name: valor_especie
+        description: "Valor total das transações feitas em espécie (R$)"
+      - name: quantidade_transacao_gratuidade
+        description: "Quantidade de transações feitas com gratuidade"
+      - name: valor_gratuidade
+        description: "Valor total das transações feitas com gratuidade (R$)"
+      - name: quantidade_transacao_integracao
+        description: "Quantidade de transações feitas com integração"
+      - name: valor_integracao
+        description: "Valor total das transações feitas com integração (R$)"
+        # faltando preencher #
+      - name: quantidade_transacao_rateio_credito
+        description:
+      - name: valor_rateio_credito
+        description:
+      - name: quantidade_transacao_rateio_debito
+        description:
+      - name: valor_rateio_debito
+        description:
+        # ----------------- #
+      - name: valor_total_transacao_bruto
+        description: "Valor total das transações realizadas (R$)"
+      - name: valor_desconto_taxa
+        description: "Valor da taxa descontado do valor total (R$)"
+      - name: valor_total_transacao_liquido
+        description: "Valor total das transações menos o valor_desconto_taxa (R$)"
+      - name: versao
+        description: "Código de controle de versão do dado (SHA Github)"
+  - name: ordem_pagamento_servico_operador_dia
+    descriptions:
+    columns:
+      - name:

--- a/models/br_rj_riodejaneiro_bilhetagem/schema.yml
+++ b/models/br_rj_riodejaneiro_bilhetagem/schema.yml
@@ -332,16 +332,14 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-        # faltando preencher #
       - name: quantidade_transacao_rateio_credito
-        description:
+        description: ""
       - name: valor_rateio_credito
-        description:
+        description: ""
       - name: quantidade_transacao_rateio_debito
-        description:
+        description: ""
       - name: valor_rateio_debito
-        description:
-        # ----------------- #
+        description: ""
       - name: valor_total_transacao_bruto
         description: "Valor total das transações realizadas (R$)"
       - name: valor_desconto_taxa
@@ -376,16 +374,14 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-        # faltando preencher #
       - name: quantidade_transacao_rateio_credito
-        description:
+        description: ""
       - name: valor_rateio_credito
-        description:
+        description: ""
       - name: quantidade_transacao_rateio_debito
-        description:
+        description: ""
       - name: valor_rateio_debito
-        description:
-        # ----------------- #
+        description: ""
       - name: valor_total_transacao_bruto
         description: "Valor total das transações realizadas (R$)"
       - name: valor_desconto_taxa
@@ -415,16 +411,14 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-        # faltando preencher #
       - name: quantidade_transacao_rateio_credito
-        description:
+        description: ""
       - name: valor_rateio_credito
-        description:
+        description: ""
       - name: quantidade_transacao_rateio_debito
-        description:
+        description: ""
       - name: valor_rateio_debito
-        description:
-        # ----------------- #
+        description: ""
       - name: valor_total_transacao_bruto
         description: "Valor total das transações realizadas (R$)"
       - name: valor_desconto_taxa
@@ -436,4 +430,93 @@ models:
   - name: ordem_pagamento_servico_operador_dia
     descriptions:
     columns:
-      - name:
+      - name: data_ordem
+        description: "Data da ordem de pagamento (partição)"
+      - name: id_consorcio
+        description: "Identificador do consórcio na tabela cadastro.consorcios"
+      - name: consorcio
+        description: "Nome do consórcio"
+      - name: id_operadora
+        description: "Identificador da operadora na tabela cadastro.operadoras"
+      - name: operadora
+        description: "Nome da operadora de transporte (mascarado se for pessoa física)"
+      - name: id_servico_jae
+        description: "Identificador da linha no banco de dados da jaé (É possível cruzar os dados com a tabela rj-smtr.cadastro.servicos usando a coluna id_servico_jae)"
+      - name: id_ordem_pagamento
+        description: "Identificador da ordem pagamento no banco de dados da Jaé"
+      - name: id_ordem_ressarcimento
+        description:
+      - name: quantidade_transacao_debito
+        description: "Quantidade de transações feitas na modalidade débito"
+      - name: valor_debito
+        description: "Valor total das transações feitas na modalidade débito (R$)"
+      - name: quantidade_transacao_especie
+        description: "Quantidade de transações feitas em espécie"
+      - name: valor_especie
+        description: "Valor total das transações feitas em espécie (R$)"
+      - name: quantidade_transacao_gratuidade
+        description: "Quantidade de transações feitas com gratuidade"
+      - name: valor_gratuidade
+        description: "Valor total das transações feitas com gratuidade (R$)"
+      - name: quantidade_transacao_integracao
+        description: "Quantidade de transações feitas com integração"
+      - name: valor_integracao
+        description: "Valor total das transações feitas com integração (R$)"
+      - name: quantidade_transacao_rateio_credito
+        description: ""
+      - name: valor_rateio_credito
+        description: ""
+      - name: quantidade_transacao_rateio_debito
+        description: ""
+      - name: valor_rateio_debito
+        description: ""
+      - name: quantidade_total_transacao
+        description: "Quantidade total de transações realizadas"
+      - name: valor_total_transacao_bruto
+        description: "Valor total das transações realizadas (R$)"
+      - name: valor_desconto_taxa
+        description: "Valor da taxa descontado do valor total (R$)"
+      - name: valor_total_transacao_liquido
+        description: "Valor total das transações menos o valor_desconto_taxa (R$)"
+      - name: quantidade_total_transacao_captura
+        description: "Quantidade total de transações calculada pela captura de transações"
+      - name: valor_total_transacao_captura
+        description: "Valor total das transações realizadas calculada pela captura de transações (R$)"
+      - name: indicador_ordem_valida
+        description: "Indicador de validação da ordem de pagamento i.e. se a quantidade e valor total informados são encontrados na captura de transações individuais"
+      - name: versao
+        description: "Código de controle de versão do dado (SHA Github)"
+  - name: transacao_riocard
+    columns:
+      - name: data
+        description: "Data da transação (partição)"
+      - name: hora
+        description: "Hora da transação"
+      - name: datetime_transacao
+        description: "Data e hora da transação em GMT-3 (formato YYYY-MM-ddTHH:mm:ss.ssssss)"
+      - name: datetime_processamento
+        description: "Data e hora de processamento da transação em GMT-3 (formato YYYY-MM-ddTHH:mm:ss.ssssss)"
+      - name: datetime_captura
+        description: "Timestamp de captura em GMT-3 (formato YYYY-MM-dd HH:mm:ssTZD)"
+      - name: id_consorcio_jae
+        description: "Código do consórcio no sistema da Jaé"
+      - name: id_operadora_jae
+        description: "Código do operador no sistema da Jaé"
+      - name: id_servico_jae
+        description: "Identificador da linha no banco de dados da jaé (É possível cruzar os dados com a tabela rj-smtr.cadastro.servicos usando a coluna id_servico_jae)"
+      - name: id_validador
+        description: "Número de série do validador"
+      - name: sentido
+        description: "Sentido de operação do serviço (0 = ida, 1 = volta)"
+      - name: id_cliente
+        description: "Identificador único do cliente"
+      - name: id_transacao
+        description: "Identificador único da transação"
+      - name: latitude
+        description: "Latitude da transação (WGS84)"
+      - name: longitude
+        description: "Longitude da transação (WGS84)"
+      - name: valor_transacao
+        description: "Valor debitado na transação atual (R$)"
+      - name: versao
+        description: "Código de controle de versão do dado (SHA Github)"

--- a/models/br_rj_riodejaneiro_bilhetagem/schema.yml
+++ b/models/br_rj_riodejaneiro_bilhetagem/schema.yml
@@ -66,7 +66,7 @@ models:
     description: "Tabela de integrações realizadas entre modos do sistema de transporte municipal, contendo os valores da repartição tarifária (quando houver). [Dados em fase de teste]"
     columns:
       - name: data
-        description: "Data da integração (partição)"
+        description: "Data da transação (partição)"
       - name: hora
         description: "Hora da transação"
       - name: datetime_processamento_integracao
@@ -74,7 +74,7 @@ models:
       - name: datetime_captura
         description: "Data e hora da captura da integração em GMT-3"
       - name: datetime_transacao
-        description: "Data e hora da integração em GMT-3"
+        description: "Data e hora da transação em GMT-3"
       - name: intervalo_integracao
         description: "Tempo entre a perna atual da integração e a anterior em minutos"
       - name: id_integracao

--- a/models/br_rj_riodejaneiro_bilhetagem/schema.yml
+++ b/models/br_rj_riodejaneiro_bilhetagem/schema.yml
@@ -123,7 +123,7 @@ models:
     description: "Tabela de integrações realizadas entre modos do sistema de transporte municipal, contendo os valores da repartição tarifária (quando houver). [Dados em fase de teste]"
     columns:
       - name: data
-        description: "Data da transação (partição)"
+        description: "Data da integração (partição)"
       - name: hora
         description: "Hora da transação"
       - name: datetime_processamento_integracao
@@ -131,7 +131,7 @@ models:
       - name: datetime_captura
         description: "Data e hora da captura da integração em GMT-3"
       - name: datetime_transacao
-        description: "Data e hora da transação em GMT-3"
+        description: "Data e hora da integração em GMT-3"
       - name: intervalo_integracao
         description: "Tempo de intervalo da integração em minutos"
       - name: id_integracao

--- a/models/br_rj_riodejaneiro_bilhetagem/schema.yml
+++ b/models/br_rj_riodejaneiro_bilhetagem/schema.yml
@@ -275,7 +275,7 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-       - name: quantidade_transacao_rateio_credito
+      - name: quantidade_transacao_rateio_credito
         description: "Quantidade total de transações consideradas no crédito da repartição tarifária"
       - name: valor_rateio_credito
         description: "Valor total creditado em decorrência da repartição tarifária (R$)"
@@ -285,6 +285,8 @@ models:
         description: "Valor total debitado em decorrência da repartição tarifária (R$)"
       - name: valor_total_transacao_bruto
         description: "Valor total das transações realizadas (R$)"
+      - name: valor_total_transacao_liquido
+        description: "Valor total das transações menos o valor_desconto_taxa (R$)"
       - name: valor_desconto_taxa
         description: "Valor da taxa descontado do valor total (R$)"
       - name: versao
@@ -320,7 +322,7 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-       - name: quantidade_transacao_rateio_credito
+      - name: quantidade_transacao_rateio_credito
         description: "Quantidade total de transações consideradas no crédito da repartição tarifária"
       - name: valor_rateio_credito
         description: "Valor total creditado em decorrência da repartição tarifária (R$)"
@@ -332,6 +334,8 @@ models:
         description: "Valor total das transações realizadas (R$)"
       - name: valor_desconto_taxa
         description: "Valor da taxa descontado do valor total (R$)"
+      - name: valor_total_transacao_liquido
+        description: "Valor total das transações menos o valor_desconto_taxa (R$)"
       - name: versao
         description: "Código de controle de versão do dado (SHA Github)"
   - name: ordem_pagamento_dia
@@ -339,6 +343,8 @@ models:
     columns:
       - name: data_ordem
         description: "Data da ordem de pagamento (partição)"
+      - name: data_pagamento
+        description: "Data de pagamento"
       - name: id_ordem_pagamento
         description: "Identificador da ordem pagamento no banco de dados da Jaé"
       - name: quantidade_transacao_debito
@@ -357,7 +363,7 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-       - name: quantidade_transacao_rateio_credito
+      - name: quantidade_transacao_rateio_credito
         description: "Quantidade total de transações consideradas no crédito da repartição tarifária"
       - name: valor_rateio_credito
         description: "Valor total creditado em decorrência da repartição tarifária (R$)"
@@ -391,7 +397,7 @@ models:
       - name: id_ordem_pagamento
         description: "Identificador da ordem pagamento no banco de dados da Jaé"
       - name: id_ordem_ressarcimento
-        description:
+        description: "Identificador da ordem ressarcimento no banco de dados da Jaé"
       - name: quantidade_transacao_debito
         description: "Quantidade de transações feitas na modalidade débito"
       - name: valor_debito
@@ -408,7 +414,7 @@ models:
         description: "Quantidade de transações feitas com integração"
       - name: valor_integracao
         description: "Valor total das transações feitas com integração (R$)"
-       - name: quantidade_transacao_rateio_credito
+      - name: quantidade_transacao_rateio_credito
         description: "Quantidade total de transações consideradas no crédito da repartição tarifária"
       - name: valor_rateio_credito
         description: "Valor total creditado em decorrência da repartição tarifária (R$)"

--- a/models/dashboard_bilhetagem_implantacao_jae/CHANGELOG.md
+++ b/models/dashboard_bilhetagem_implantacao_jae/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - dashboard_bilhetagem_implantacao_jae
 
-## [1.0.0] - 2024-04-12
+## [1.0.0] - 2024-04-15
 
 ### Adicionado 
 

--- a/models/dashboard_bilhetagem_implantacao_jae/CHANGELOG.md
+++ b/models/dashboard_bilhetagem_implantacao_jae/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - dashboard_bilhetagem_implantacao_jae
+
+## [1.0.0] - 2024-04-12
+
+### Adicionado 
+
+- Adicionada descrições das colunas das tabelas: `gps_agregado_brt`, `gps_agregado_onibus`, `gps_agregado_van`, `gps_agregado__vlt`

--- a/models/dashboard_bilhetagem_implantacao_jae/schema.yml
+++ b/models/dashboard_bilhetagem_implantacao_jae/schema.yml
@@ -2,11 +2,12 @@ version: 2
 
 models:
   - name: gps_agregado_brt
+    description: "Tabela com registros de GPS do BRT utilizada no dashboard de acompanhamento da implantação dos validadores da Jaé (Contem apenas dados do dia atual)"
     columns:
       - name: servico
         description: "Nome curto da linha operada com variação de serviço (ex: 010, 011SN, ...)"
       - name: id_validador
-        description: "Número de série do validador"
+        description: "Número de série do validador da Jaé"
       - name: latitude
         description: "Parte da coordenada geográfica (eixo y) em graus decimais (EPSG:4326 - WGS84)"
       - name: longitude
@@ -14,11 +15,12 @@ models:
       - name: data
         description: "Data do 'timestamp_captura'"
   - name: gps_agregado_onibus
+    description: "Tabela com registros de GPS dos ônibus utilizada no dashboard de acompanhamento da implantação dos validadores da Jaé (Contem apenas dados do dia atual)"
     columns:
       - name: operadora
         description: "Nome da operadora de transporte (mascarado se for pessoa física)"
       - name: id_validador
-        description: "Número de série do validador"
+        description: "Número de série do validador da Jaé"
       - name: latitude
         description: "Parte da coordenada geográfica (eixo y) em graus decimais (EPSG:4326 - WGS84)"
       - name: longitude
@@ -26,24 +28,25 @@ models:
       - name: data
         description: "Data do 'timestamp_captura'"
       - name: estado_equipamento
-        description:
+        description: Estado do validador da Jaé (ABERTO ou FECHADO)
       - name: primeiro_datetime_gps
-        description:
+        description: "Data e hora do primeiro sinal de GPS transmitido pelo validador da Jaé em GMT-3"
       - name: ultimo_datetime_gps
-        description:
+        description: "Data e hora do último sinal de GPS transmitido pelo validador da Jaé em GMT-3"
       - name: qtde_min_entre_a_prim_e_ultima_transmissao
-        description:
+        description: "Quantidade em minutos entre a primeira e a ultima transmissão do GPS do validador da Jaé"
       - name: qtde_min_distintos_houve_transmissao
-        description:
+        description: "Quantidade de minutos distintos em que foram recebidas transmissões de GPS do validador da Jaé"
       - name: qtde_registros_gps
-        description:
+        description: "Quantidade de sinais transmitidos pelo GPS do validador da Jaé"
       - name: qtde_registros_gps_georreferenciados
-        description:
+        description: "Quantidade de sinais transmitidos pelo validador da Jaé com latitude e longitude não nulos ou diferentes de zero"
       - name: percentual_registros_gps_georreferenciados
-        description:
+        description: "Percentual de sinais transmitidos pelo validador da Jaé  com latitude e longitude não nulos ou diferentes de zero"
       - name: percentual_transmissao_a_cada_min
-        description:
+        description: "Percentual de minutos em que houve sinal de GPS recebido durante o tempo em que o validador da Jaé ficou ativo."
   - name: gps_agregado_van
+    description: "Tabela com registros de GPS das Vans utilizada no dashboard de acompanhamento da implantação dos validadores da Jaé (Contem apenas dados do dia atual)"
     columns:
       - name: id_operadora
         description: "Identificador da operadora na tabela cadastro.operadoras"
@@ -52,25 +55,25 @@ models:
       - name: data
         description: "Data do 'timestamp_captura'"
       - name: estado_equipamento
-        description:
+        description: Estado do validador da Jaé (ABERTO ou FECHADO)
       - name: primeiro_datetime_gps
-        description:
+        description: "Data e hora do primeiro sinal de GPS transmitido pelo validador da Jaé em GMT-3"
       - name: ultimo_datetime_gps
-        description:
+        description: "Data e hora do último sinal de GPS transmitido pelo validador da Jaé em GMT-3"
       - name: qtde_min_entre_a_prim_e_ultima_transmissao
-        description:
+        description: "Quantidade em minutos entre a primeira e a ultima transmissão do GPS do validador da Jaé"
       - name: qtde_min_distintos_houve_transmissao
-        description:
+        description: "Quantidade de minutos distintos em que foram recebidas transmissões de GPS do validador da Jaé"
       - name: qtde_registros_gps
-        description:
+        description: "Quantidade de sinais transmitidos pelo GPS do validador da Jaé"
       - name: qtde_registros_gps_georreferenciados
-        description:
+        description: "Quantidade de sinais transmitidos pelo validador da Jaé com latitude e longitude não nulos ou diferentes de zero"
       - name: percentual_registros_gps_georreferenciados
-        description:
+        description: "Percentual de sinais transmitidos pelo validador da Jaé  com latitude e longitude não nulos ou diferentes de zero"
       - name: percentual_transmissao_a_cada_min
-        description:
-      
+        description: "Percentual de minutos em que houve sinal de GPS recebido durante o tempo em que o validador da Jaé ficou ativo."
   - name: gps_agregado_vlt
+    description: "Tabela com registros agregados de GPS das VLTs utilizada no dashboard de acompanhamento da implantação dos validadores da Jaé (Contem apenas dados do dia atual)"
     columns:
       - name: servico
         description: "Nome curto da linha operada com variação de serviço (ex: 010, 011SN, ...)"
@@ -83,20 +86,20 @@ models:
       - name: data
         description: "Data do 'timestamp_captura'"
       - name: estado_equipamento
-        description:
+        description: Estado do validador da Jaé (ABERTO ou FECHADO)
       - name: primeiro_datetime_gps
-        description:
+        description: "Data e hora do primeiro sinal de GPS transmitido pelo validador da Jaé em GMT-3"
       - name: ultimo_datetime_gps
-        description:
+        description: "Data e hora do último sinal de GPS transmitido pelo validador da Jaé em GMT-3"
       - name: qtde_min_entre_a_prim_e_ultima_transmissao
-        description:
+        description: "Quantidade em minutos entre a primeira e a ultima transmissão do GPS do validador da Jaé"
       - name: qtde_min_distintos_houve_transmissao
-        description:
+        description: "Quantidade de minutos distintos em que foram recebidas transmissões de GPS do validador da Jaé"
       - name: qtde_registros_gps
-        description:
+        description: "Quantidade de sinais transmitidos pelo GPS do validador da Jaé"
       - name: qtde_registros_gps_georreferenciados
-        description:
+        description: "Quantidade de sinais transmitidos pelo validador da Jaé com latitude e longitude não nulos ou diferentes de zero"
       - name: percentual_registros_gps_georreferenciados
-        description:
+        description: "Percentual de sinais transmitidos pelo validador da Jaé  com latitude e longitude não nulos ou diferentes de zero"
       - name: percentual_transmissao_a_cada_min
-        description:
+        description: "Percentual de minutos em que houve sinal de GPS recebido durante o tempo em que o validador da Jaé ficou ativo."

--- a/models/dashboard_bilhetagem_implantacao_jae/schema.yml
+++ b/models/dashboard_bilhetagem_implantacao_jae/schema.yml
@@ -1,0 +1,102 @@
+version: 2
+
+models:
+  - name: gps_agregado_brt
+    columns:
+      - name: servico
+        description: "Nome curto da linha operada com variação de serviço (ex: 010, 011SN, ...)"
+      - name: id_validador
+        description: "Número de série do validador"
+      - name: latitude
+        description: "Parte da coordenada geográfica (eixo y) em graus decimais (EPSG:4326 - WGS84)"
+      - name: longitude
+        description: "Parte da coordenada geográfica (eixo x) em graus decimais (EPSG:4326 - WGS84)"
+      - name: data
+        description: "Data do 'timestamp_captura'"
+  - name: gps_agregado_onibus
+    columns:
+      - name: operadora
+        description: "Nome da operadora de transporte (mascarado se for pessoa física)"
+      - name: id_validador
+        description: "Número de série do validador"
+      - name: latitude
+        description: "Parte da coordenada geográfica (eixo y) em graus decimais (EPSG:4326 - WGS84)"
+      - name: longitude
+        description: "Parte da coordenada geográfica (eixo x) em graus decimais (EPSG:4326 - WGS84)"
+      - name: data
+        description: "Data do 'timestamp_captura'"
+      - name: estado_equipamento
+        description:
+      - name: primeiro_datetime_gps
+        description:
+      - name: ultimo_datetime_gps
+        description:
+      - name: qtde_min_entre_a_prim_e_ultima_transmissao
+        description:
+      - name: qtde_min_distintos_houve_transmissao
+        description:
+      - name: qtde_registros_gps
+        description:
+      - name: qtde_registros_gps_georreferenciados
+        description:
+      - name: percentual_registros_gps_georreferenciados
+        description:
+      - name: percentual_transmissao_a_cada_min
+        description:
+  - name: gps_agregado_van
+    columns:
+      - name: id_operadora
+        description: "Identificador da operadora na tabela cadastro.operadoras"
+      - name: id_validador
+        description: "Número de série do validador"
+      - name: data
+        description: "Data do 'timestamp_captura'"
+      - name: estado_equipamento
+        description:
+      - name: primeiro_datetime_gps
+        description:
+      - name: ultimo_datetime_gps
+        description:
+      - name: qtde_min_entre_a_prim_e_ultima_transmissao
+        description:
+      - name: qtde_min_distintos_houve_transmissao
+        description:
+      - name: qtde_registros_gps
+        description:
+      - name: qtde_registros_gps_georreferenciados
+        description:
+      - name: percentual_registros_gps_georreferenciados
+        description:
+      - name: percentual_transmissao_a_cada_min
+        description:
+      
+  - name: gps_agregado_vlt
+    columns:
+      - name: servico
+        description: "Nome curto da linha operada com variação de serviço (ex: 010, 011SN, ...)"
+      - name: id_validador
+        description: "Número de série do validador"
+      - name: latitude
+        description: "Parte da coordenada geográfica (eixo y) em graus decimais (EPSG:4326 - WGS84)"
+      - name: longitude
+        description: "Parte da coordenada geográfica (eixo x) em graus decimais (EPSG:4326 - WGS84)"
+      - name: data
+        description: "Data do 'timestamp_captura'"
+      - name: estado_equipamento
+        description:
+      - name: primeiro_datetime_gps
+        description:
+      - name: ultimo_datetime_gps
+        description:
+      - name: qtde_min_entre_a_prim_e_ultima_transmissao
+        description:
+      - name: qtde_min_distintos_houve_transmissao
+        description:
+      - name: qtde_registros_gps
+        description:
+      - name: qtde_registros_gps_georreferenciados
+        description:
+      - name: percentual_registros_gps_georreferenciados
+        description:
+      - name: percentual_transmissao_a_cada_min
+        description:

--- a/models/dashboard_bilhetagem_implantacao_jae/schema.yml
+++ b/models/dashboard_bilhetagem_implantacao_jae/schema.yml
@@ -14,6 +14,24 @@ models:
         description: "Parte da coordenada geográfica (eixo x) em graus decimais (EPSG:4326 - WGS84)"
       - name: data
         description: "Data do 'timestamp_captura'"
+      - name: estado_equipamento
+        description: Estado do validador da Jaé (ABERTO ou FECHADO)
+      - name: primeiro_datetime_gps
+        description: "Data e hora do primeiro sinal de GPS transmitido pelo validador da Jaé em GMT-3"
+      - name: ultimo_datetime_gps
+        description: "Data e hora do último sinal de GPS transmitido pelo validador da Jaé em GMT-3"
+      - name: qtde_min_entre_a_prim_e_ultima_transmissao
+        description: "Quantidade em minutos entre a primeira e a ultima transmissão do GPS do validador da Jaé"
+      - name: qtde_min_distintos_houve_transmissao
+        description: "Quantidade de minutos distintos em que foram recebidas transmissões de GPS do validador da Jaé"
+      - name: qtde_registros_gps
+        description: "Quantidade de sinais transmitidos pelo GPS do validador da Jaé"
+      - name: qtde_registros_gps_georreferenciados
+        description: "Quantidade de sinais transmitidos pelo validador da Jaé com latitude e longitude não nulos ou diferentes de zero"
+      - name: percentual_registros_gps_georreferenciados
+        description: "Percentual de sinais transmitidos pelo validador da Jaé  com latitude e longitude não nulos ou diferentes de zero"
+      - name: percentual_transmissao_a_cada_min
+        description: "Percentual de minutos em que houve sinal de GPS recebido durante o tempo em que o validador da Jaé ficou ativo."
   - name: gps_agregado_onibus
     description: "Tabela com registros de GPS dos ônibus utilizada no dashboard de acompanhamento da implantação dos validadores da Jaé (Contem apenas dados do dia atual)"
     columns:


### PR DESCRIPTION
## Changelog
- Adicionadas descrições das tabelas `ordem_pagamento_consorcio_dia`, `ordem_pagamento_consorcio_operador_dia`, `ordem_pagamento_dia`,`transacao_riocard` e Bilhetagem
- Adicionadas descrições das tabelas `gps_agregado_brt`, `gps_agregado_onibus`, `gps_agregado_van`, `gps_agregado__vlt` de dashboard_bilhetagem_implantacao_jae


## Checklist

- [ ] Já testei os modelos no BigQuery
- [ ] Já existe pipeline no Prefect
- [ ] Título do PR está 💯

> Utilize os seguintes padrões de nomeação:
> 
> 1. Alterações em modelos: `[smtr][pipeline/dataset sem prefixo*] <fix/feat>: <descricao>`
> 2. Alterações no repositório: `[smtr][infra] <fix/feat>: <descricao>`
>
> \* Ex: br_rj_riodejaneiro_onibus_gps -> onibus_gps
