### PR TITLE
Bilhetagem - Filtra transação inválidas ou de teste

### DIFF
--- a/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -8,6 +8,7 @@
     - datas anteriores a 2023-07-17
   - Transações teste:
     - linhas sem ressarcimento
+- Limita quantidade de ids listados no filtro da tabela de gratuidades no modelo `transacao.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/275)
 
 ## [1.0.1] - 2024-04-16
 

--- a/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog - bilhetagem
 
+## [1.0.2] - 2024-04-17
+
+### Corrigido
+- Filtra transações inválidas ou de teste no modelo `transacao.sql`
+  - Transações inválidas:
+    - datas anteriores a 2023-07-17
+  - Transações teste:
+    - linhas sem ressarcimento 
+
 ## [1.0.0] - 2024-04-05
 
 ### Adicionado

--- a/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - bilhetagem
 
-## [1.0.2] - 2024-04-17
+## [1.0.2] - 2024-04-18
 
 ### Modificado
 - Filtra transações inválidas ou de teste no modelo `transacao.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/275)

--- a/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## [1.0.2] - 2024-04-17
 
 ### Modificado
-- Filtra transações inválidas ou de teste no modelo `transacao.sql`
+- Filtra transações inválidas ou de teste no modelo `transacao.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/275)
   - Transações inválidas:
     - datas anteriores a 2023-07-17
   - Transações teste:
-    - linhas sem ressarcimento 
+    - linhas sem ressarcimento
 
 ## [1.0.1] - 2024-04-16
 

--- a/models/br_rj_riodejaneiro_bilhetagem/integracao.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/integracao.sql
@@ -115,9 +115,23 @@ integracao_rn AS (
   ON
     i.id_consorcio = dc.id_consorcio_jae
   WHERE i.id_transacao IS NOT NULL
+),
+integracoes_teste_invalidas AS (
+  SELECT DISTINCT
+    i.id_integracao
+  FROM
+    integracao_rn i
+  LEFT JOIN
+    {{ ref("staging_linha_sem_ressarcimento") }} l
+  ON
+    i.id_servico_jae = l.id_linha
+  WHERE
+    l.id_linha IS NOT NULL
+    OR i.data < "2023-07-17"
 )
 SELECT
   * EXCEPT(rn)
 FROM
   integracao_rn
 WHERE rn = 1
+AND id_integracao NOT IN (SELECT id_integracao FROM integracoes_teste_invalidas)

--- a/models/br_rj_riodejaneiro_bilhetagem/transacao.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/transacao.sql
@@ -73,13 +73,13 @@ gratuidade AS (
         {{ ref("gratuidade_aux") }}
     -- se for incremental pega apenas as partições necessárias
     {% if is_incremental() %}
-            {% if gratuidade_partition_list|length > 0 and gratuidade_partition_list|length < 1000%}
-                WHERE
-                    id_cliente IN ({{ gratuidade_partition_list|join(', ') }})
-            {% else %}
-                WHERE
-                    id_cliente = 0
-            {% endif %}
+        {% if gratuidade_partition_list|length > 0 and gratuidade_partition_list|length < 1000%}
+            WHERE
+                id_cliente IN ({{ gratuidade_partition_list|join(', ') }})
+        {% elif gratuidade_partition_list|length = 0 %}
+            WHERE
+                id_cliente = 0
+        {% endif %}
     {% endif %}
 ),
 tipo_pagamento AS (

--- a/models/br_rj_riodejaneiro_bilhetagem/transacao.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/transacao.sql
@@ -73,7 +73,7 @@ gratuidade AS (
         {{ ref("gratuidade_aux") }}
     -- se for incremental pega apenas as partições necessárias
     {% if is_incremental() %}
-        {% if gratuidade_partition_list|length > 0 and gratuidade_partition_list|length < 1000%}
+        {% if gratuidade_partition_list|length > 0 and gratuidade_partition_list|length < 1000 %}
             WHERE
                 id_cliente IN ({{ gratuidade_partition_list|join(', ') }})
         {% elif gratuidade_partition_list|length = 0 %}

--- a/models/br_rj_riodejaneiro_bilhetagem/transacao.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/transacao.sql
@@ -76,7 +76,7 @@ gratuidade AS (
         {% if gratuidade_partition_list|length > 0 and gratuidade_partition_list|length < 1000 %}
             WHERE
                 id_cliente IN ({{ gratuidade_partition_list|join(', ') }})
-        {% elif gratuidade_partition_list|length = 0 %}
+        {% elif gratuidade_partition_list|length == 0 %}
             WHERE
                 id_cliente = 0
         {% endif %}

--- a/models/br_rj_riodejaneiro_bilhetagem/transacao.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/transacao.sql
@@ -47,7 +47,8 @@ WITH transacao_deduplicada AS (
         FROM
             {{ transacao_staging }}
         {% if is_incremental() -%}
-            {{ incremental_filter }}
+            WHERE
+                {{ incremental_filter }}
         {%- endif %}
     )
     WHERE
@@ -73,7 +74,7 @@ gratuidade AS (
         {{ ref("gratuidade_aux") }}
     -- se for incremental pega apenas as partições necessárias
     {% if is_incremental() %}
-        {% if gratuidade_partition_list|length > 0 and gratuidade_partition_list|length < 1000 %}
+        {% if gratuidade_partition_list|length > 0 and gratuidade_partition_list|length < 10000 %}
             WHERE
                 id_cliente IN ({{ gratuidade_partition_list|join(', ') }})
         {% elif gratuidade_partition_list|length == 0 %}


### PR DESCRIPTION
## Changelog
- bilhetagem.transacao
  - Limita a quantidade de ids da gratuidade para filtrar
- bilhetagem.transacao e bilhetagem.integracao
  - Filtra transações de teste com base nas linhas sem ressarcimento
  - Filtra transações com datas anteriores a 2023-07-17


## Checklist

- [x] Já testei os modelos no BigQuery
- [x] Já existe pipeline no Prefect
- [x] Título do PR está 💯