### PR TITLE
[HOTFIX] Bilhetagem - Remove arredondamento das ordens de pagamento

### DIFF
--- a/models/br_rj_riodejaneiro_bilhetagem/ordem_pagamento_consorcio_dia.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/ordem_pagamento_consorcio_dia.sql
@@ -28,9 +28,9 @@ SELECT
     o.valor_rateio_credito AS valor_rateio_credito,
     o.qtd_rateio_debito AS quantidade_transacao_rateio_debito,
     o.valor_rateio_debito AS valor_rateio_debito,
-    ROUND(o.valor_bruto + 0.0005, 2) AS valor_total_transacao_bruto,
+    o.valor_bruto AS valor_total_transacao_bruto,
     o.valor_taxa AS valor_desconto_taxa,
-    ROUND(o.valor_liquido + 0.0005, 2) AS valor_total_transacao_liquido,
+    o.valor_liquido AS valor_total_transacao_liquido,
     '{{ var("version") }}' AS versao
 FROM 
     {{ ref("staging_ordem_pagamento_consorcio") }} o

--- a/models/br_rj_riodejaneiro_bilhetagem/ordem_pagamento_consorcio_operador_dia.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/ordem_pagamento_consorcio_operador_dia.sql
@@ -30,9 +30,9 @@ SELECT
     o.valor_rateio_credito AS valor_rateio_credito,
     o.qtd_rateio_debito AS quantidade_transacao_rateio_debito,
     o.valor_rateio_debito AS valor_rateio_debito,
-    ROUND(o.valor_bruto + 0.0005, 2) AS valor_total_transacao_bruto,
+    o.valor_bruto AS valor_total_transacao_bruto,
     o.valor_taxa AS valor_desconto_taxa,
-    ROUND(o.valor_liquido + 0.0005, 2) AS valor_total_transacao_liquido,
+    o.valor_liquido AS valor_total_transacao_liquido,
     '{{ var("version") }}' AS versao
 FROM 
     {{ ref('staging_ordem_pagamento_consorcio_operadora') }} o

--- a/models/br_rj_riodejaneiro_bilhetagem/ordem_pagamento_dia.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/ordem_pagamento_dia.sql
@@ -27,9 +27,9 @@ SELECT
     o.valor_rateio_credito AS valor_rateio_credito,
     o.qtd_rateio_debito AS quantidade_transacao_rateio_debito,
     o.valor_rateio_debito AS valor_rateio_debito,
-    ROUND(o.valor_bruto + 0.0005, 2) AS valor_total_transacao_bruto,
+    o.valor_bruto AS valor_total_transacao_bruto,
     o.valor_taxa AS valor_desconto_taxa,
-    ROUND(o.valor_liquido + 0.0005, 2) AS valor_total_transacao_liquido,
+    o.valor_liquido AS valor_total_transacao_liquido,
     '{{ var("version") }}' AS versao
 FROM 
     {{ ref('staging_ordem_pagamento') }} o

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_pagamento.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_pagamento.sql
@@ -19,15 +19,15 @@ WITH ordem_pagamento AS (
     SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_credito') AS INTEGER) AS qtd_rateio_credito,
     SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_debito') AS INTEGER) AS qtd_rateio_debito,
     SAFE_CAST(JSON_VALUE(content, '$.qtd_vendaabordo') AS INTEGER) AS qtd_vendaabordo,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_bruto') AS FLOAT64) AS valor_bruto,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_debito') AS FLOAT64) AS valor_debito,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_gratuidade') AS FLOAT64) AS valor_gratuidade,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_integracao') AS FLOAT64) AS valor_integracao,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_liquido') AS FLOAT64) AS valor_liquido,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_credito') AS FLOAT64) AS valor_rateio_credito,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_debito') AS FLOAT64) AS valor_rateio_debito,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_taxa') AS FLOAT64) AS valor_taxa,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_vendaabordo') AS FLOAT64) AS valor_vendaabordo
+    SAFE_CAST(JSON_VALUE(content, '$.valor_bruto') AS NUMERIC) AS valor_bruto,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_debito') AS NUMERIC) AS valor_debito,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_gratuidade') AS NUMERIC) AS valor_gratuidade,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_integracao') AS NUMERIC) AS valor_integracao,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_liquido') AS NUMERIC) AS valor_liquido,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_credito') AS NUMERIC) AS valor_rateio_credito,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_debito') AS NUMERIC) AS valor_rateio_debito,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_taxa') AS NUMERIC) AS valor_taxa,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_vendaabordo') AS NUMERIC) AS valor_vendaabordo
   FROM
     {{ source("br_rj_riodejaneiro_bilhetagem_staging", "ordem_pagamento") }}
 ),

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_pagamento_consorcio.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_pagamento_consorcio.sql
@@ -19,15 +19,15 @@ WITH ordem_pagamento_consorcio AS (
     SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_credito') AS INTEGER) AS qtd_rateio_credito,
     SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_debito') AS INTEGER) AS qtd_rateio_debito,
     SAFE_CAST(JSON_VALUE(content, '$.qtd_vendaabordo') AS INTEGER) AS qtd_vendaabordo,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_bruto') AS FLOAT64) AS valor_bruto,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_debito') AS FLOAT64) AS valor_debito,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_gratuidade') AS FLOAT64) AS valor_gratuidade,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_integracao') AS FLOAT64) AS valor_integracao,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_liquido') AS FLOAT64) AS valor_liquido,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_credito') AS FLOAT64) AS valor_rateio_credito,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_debito') AS FLOAT64) AS valor_rateio_debito,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_taxa') AS FLOAT64) AS valor_taxa,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_vendaabordo') AS FLOAT64) AS valor_vendaabordo
+    SAFE_CAST(JSON_VALUE(content, '$.valor_bruto') AS NUMERIC) AS valor_bruto,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_debito') AS NUMERIC) AS valor_debito,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_gratuidade') AS NUMERIC) AS valor_gratuidade,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_integracao') AS NUMERIC) AS valor_integracao,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_liquido') AS NUMERIC) AS valor_liquido,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_credito') AS NUMERIC) AS valor_rateio_credito,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_debito') AS NUMERIC) AS valor_rateio_debito,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_taxa') AS NUMERIC) AS valor_taxa,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_vendaabordo') AS NUMERIC) AS valor_vendaabordo
   FROM
       {{ source("br_rj_riodejaneiro_bilhetagem_staging", "ordem_pagamento_consorcio") }}
 ),

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_pagamento_consorcio_operadora.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_pagamento_consorcio_operadora.sql
@@ -20,15 +20,15 @@ WITH ordem_pagamento_consorcio_operadora AS (
     SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_credito') AS INTEGER) AS qtd_rateio_credito,
     SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_debito') AS INTEGER) AS qtd_rateio_debito,
     SAFE_CAST(JSON_VALUE(content, '$.qtd_vendaabordo') AS INTEGER) AS qtd_vendaabordo,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_bruto') AS FLOAT64) AS valor_bruto,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_debito') AS FLOAT64) AS valor_debito,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_gratuidade') AS FLOAT64) AS valor_gratuidade,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_integracao') AS FLOAT64) AS valor_integracao,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_liquido') AS FLOAT64) AS valor_liquido,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_credito') AS FLOAT64) AS valor_rateio_credito,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_debito') AS FLOAT64) AS valor_rateio_debito,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_taxa') AS FLOAT64) AS valor_taxa,
-    SAFE_CAST(JSON_VALUE(content, '$.valor_vendaabordo') AS FLOAT64) AS valor_vendaabordo
+    SAFE_CAST(JSON_VALUE(content, '$.valor_bruto') AS NUMERIC) AS valor_bruto,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_debito') AS NUMERIC) AS valor_debito,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_gratuidade') AS NUMERIC) AS valor_gratuidade,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_integracao') AS NUMERIC) AS valor_integracao,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_liquido') AS NUMERIC) AS valor_liquido,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_credito') AS NUMERIC) AS valor_rateio_credito,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_debito') AS NUMERIC) AS valor_rateio_debito,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_taxa') AS NUMERIC) AS valor_taxa,
+    SAFE_CAST(JSON_VALUE(content, '$.valor_vendaabordo') AS NUMERIC) AS valor_vendaabordo
   FROM
       {{ source("br_rj_riodejaneiro_bilhetagem_staging", "ordem_pagamento_consorcio_operadora") }}
 ),

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_rateio.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_rateio.sql
@@ -30,18 +30,18 @@ WITH ordem_rateio AS (
         SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_debito_t3') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_debito_t3,
         SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_debito_t4') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_debito_t4,
         SAFE_CAST(SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_compensacao_debito_total') AS FLOAT64) AS INTEGER) AS qtd_rateio_compensacao_debito_total,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t0') AS FLOAT64) AS valor_rateio_compensacao_credito_t0,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t1') AS FLOAT64) AS valor_rateio_compensacao_credito_t1,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t2') AS FLOAT64) AS valor_rateio_compensacao_credito_t2,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t3') AS FLOAT64) AS valor_rateio_compensacao_credito_t3,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t4') AS FLOAT64) AS valor_rateio_compensacao_credito_t4,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_total') AS FLOAT64) AS valor_rateio_compensacao_credito_total,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t0') AS FLOAT64) AS valor_rateio_compensacao_debito_t0,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t1') AS FLOAT64) AS valor_rateio_compensacao_debito_t1,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t2') AS FLOAT64) AS valor_rateio_compensacao_debito_t2,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t3') AS FLOAT64) AS valor_rateio_compensacao_debito_t3,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t4') AS FLOAT64) AS valor_rateio_compensacao_debito_t4,
-        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_total') AS FLOAT64) AS valor_rateio_compensacao_debito_total
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t0') AS NUMERIC) AS valor_rateio_compensacao_credito_t0,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t1') AS NUMERIC) AS valor_rateio_compensacao_credito_t1,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t2') AS NUMERIC) AS valor_rateio_compensacao_credito_t2,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t3') AS NUMERIC) AS valor_rateio_compensacao_credito_t3,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_t4') AS NUMERIC) AS valor_rateio_compensacao_credito_t4,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_credito_total') AS NUMERIC) AS valor_rateio_compensacao_credito_total,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t0') AS NUMERIC) AS valor_rateio_compensacao_debito_t0,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t1') AS NUMERIC) AS valor_rateio_compensacao_debito_t1,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t2') AS NUMERIC) AS valor_rateio_compensacao_debito_t2,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t3') AS NUMERIC) AS valor_rateio_compensacao_debito_t3,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_t4') AS NUMERIC) AS valor_rateio_compensacao_debito_t4,
+        SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_compensacao_debito_total') AS NUMERIC) AS valor_rateio_compensacao_debito_total
   FROM
     {{ source('br_rj_riodejaneiro_bilhetagem_staging', 'ordem_rateio') }}
 )

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_ressarcimento.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/staging_ordem_ressarcimento.sql
@@ -25,15 +25,15 @@ WITH
             SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_credito') AS INTEGER) AS qtd_rateio_credito,
             SAFE_CAST(JSON_VALUE(content, '$.qtd_rateio_debito') AS INTEGER) AS qtd_rateio_debito,
             SAFE_CAST(JSON_VALUE(content, '$.qtd_vendaabordo') AS INTEGER) AS qtd_vendaabordo,
-            SAFE_CAST(JSON_VALUE(content, '$.valor_bruto') AS FLOAT64) AS valor_bruto,
-            SAFE_CAST(JSON_VALUE(content, '$.valor_debito') AS FLOAT64) AS valor_debito,
-            SAFE_CAST(JSON_VALUE(content, '$.valor_gratuidade') AS FLOAT64) AS valor_gratuidade,
-            SAFE_CAST(JSON_VALUE(content, '$.valor_integracao') AS FLOAT64) AS valor_integracao,
-            SAFE_CAST(JSON_VALUE(content, '$.valor_liquido') AS FLOAT64) AS valor_liquido,
-            SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_credito') AS FLOAT64) AS valor_rateio_credito,
-            SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_debito') AS FLOAT64) AS valor_rateio_debito,
-            SAFE_CAST(JSON_VALUE(content, '$.valor_taxa') AS FLOAT64) AS valor_taxa,
-            SAFE_CAST(JSON_VALUE(content, '$.valor_vendaabordo') AS FLOAT64) AS valor_vendaabordo
+            SAFE_CAST(JSON_VALUE(content, '$.valor_bruto') AS NUMERIC) AS valor_bruto,
+            SAFE_CAST(JSON_VALUE(content, '$.valor_debito') AS NUMERIC) AS valor_debito,
+            SAFE_CAST(JSON_VALUE(content, '$.valor_gratuidade') AS NUMERIC) AS valor_gratuidade,
+            SAFE_CAST(JSON_VALUE(content, '$.valor_integracao') AS NUMERIC) AS valor_integracao,
+            SAFE_CAST(JSON_VALUE(content, '$.valor_liquido') AS NUMERIC) AS valor_liquido,
+            SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_credito') AS NUMERIC) AS valor_rateio_credito,
+            SAFE_CAST(JSON_VALUE(content, '$.valor_rateio_debito') AS NUMERIC) AS valor_rateio_debito,
+            SAFE_CAST(JSON_VALUE(content, '$.valor_taxa') AS NUMERIC) AS valor_taxa,
+            SAFE_CAST(JSON_VALUE(content, '$.valor_vendaabordo') AS NUMERIC) AS valor_vendaabordo
         FROM
             {{ source("br_rj_riodejaneiro_bilhetagem_staging", "ordem_ressarcimento") }}
     ),


### PR DESCRIPTION
## Changelog
- Removido tratamento de arredondamento nos valores totais:
  - `bilhetagem.ordem_pagamento_dia`
  - `bilhetagem.ordem_pagamento_consorcio_operador_dia`
  - `bilhetagem.ordem_pagamento_consorcio_dia`
  
- Alterado cast de float para numeric:
  - `bilhetagem_staging.staging_ordem_pagamento`
  - `bilhetagem_staging.staging_ordem_pagamento_consorcio`
  - `bilhetagem_staging.staging_ordem_pagamento_consorcio_operadora`
  - `bilhetagem_staging.staging_ordem_rateio`
  - `bilhetagem_staging.staging_ordem_ressarcimento` 