### PR TITLE
Remove planejamento específico do evento "Madonna" no modelo `subsidio_data_versao_efetiva.sql`

### DIFF
--- a/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog - projeto_subsidio_sppo
 
+## [6.0.4] - 2024-05-08
+
+### Adicionado
+
+- Adicionado planejamento de Maio/Q1/2024 no modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/299)
+- Adicionado planejamento específico de `2024-05-04` e `2024-05-05` em razão do evento "Madonna · The Celebration Tour in Rio" (Processo Rio MTR-PRO-2024/06338) no modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/299)
+
+### Corrigido
+
+- Corrigido tratamento do modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/299)
+
 ## [6.0.3] - 2024-04-29
 
 ### Corrigido

--- a/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [6.0.5] - 2024-05-08
+
+### Removido
+
+- Removido planejamento específico de `2024-05-04` e `2024-05-05` em razão do evento "Madonna · The Celebration Tour in Rio" (Processo Rio MTR-PRO-2024/06338) no modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/300)
+
 ## [6.0.4] - 2024-05-08
 
 ### Adicionado

--- a/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -346,11 +346,12 @@ WITH
       WHEN data BETWEEN DATE(2024,04,15) AND DATE(2024,05,02) THEN "2024-04-15"  -- OS abr/Q2
       WHEN data BETWEEN DATE(2024,05,03) AND DATE(2024,05,31) THEN "2024-05-03"  -- OS maio/Q1
     END AS feed_version,
-    CASE
-      WHEN data = DATE(2024,05,04) THEN "Madonna 2024-05-04"
-      WHEN data = DATE(2024,05,05) THEN "Madonna 2024-05-05"
-      ELSE "Regular"
-    END AS tipo_os,
+    -- CASE
+    --   WHEN data = DATE(2024,05,04) THEN "Madonna 2024-05-04"
+    --   WHEN data = DATE(2024,05,05) THEN "Madonna 2024-05-05"
+    --   ELSE "Regular"
+    -- END AS tipo_os,
+    "Regular" AS tipo_os,
   FROM UNNEST(GENERATE_DATE_ARRAY("{{var('DATA_SUBSIDIO_V6_INICIO')}}", "2024-12-31")) AS data)
 SELECT
   data,


### PR DESCRIPTION
# Changelog - projeto_subsidio_sppo

## [6.0.5] - 2024-05-08

### Removido

- Removido planejamento específico de `2024-05-04` e `2024-05-05` em razão do evento "Madonna · The Celebration Tour in Rio" (Processo Rio MTR-PRO-2024/06338) no modelo `subsidio_data_versao_efetiva.sql`