### PR TITLE
Bilhetagem - Adiciona coluna `servico` nas tabelas da Jaé

### DIFF
--- a/models/br_rj_riodejaneiro_bilhetagem/gps_validador.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/gps_validador.sql
@@ -17,6 +17,7 @@ SELECT
     datetime_captura,
     id_operadora,
     operadora,
+    id_servico_jae,
     servico,
     CASE
       WHEN modo = "VLT" THEN SUBSTRING(id_veiculo, 1, 3)

--- a/models/br_rj_riodejaneiro_bilhetagem/gps_validador_van.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/gps_validador_van.sql
@@ -17,6 +17,7 @@ SELECT
     datetime_captura,
     id_operadora,
     operadora,
+    id_servico_jae,
     servico,
     id_veiculo,
     id_validador,

--- a/models/br_rj_riodejaneiro_bilhetagem/integracao.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/integracao.sql
@@ -90,6 +90,7 @@ integracao_rn AS (
     do.id_operadora,
     do.operadora,
     i.id_linha AS id_servico_jae,
+    s.servico,
     i.id_transacao,
     i.sentido,
     i.perc_rateio AS percentual_rateio,
@@ -114,6 +115,10 @@ integracao_rn AS (
     {{ ref("consorcios") }} AS dc
   ON
     i.id_consorcio = dc.id_consorcio_jae
+  LEFT JOIN
+    {{ ref("servicos") }} AS s
+  ON
+    i.id_linha = s.id_servico_jae
   WHERE i.id_transacao IS NOT NULL
 ),
 integracoes_teste_invalidas AS (

--- a/models/br_rj_riodejaneiro_bilhetagem/ordem_pagamento_servico_operador_dia.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/ordem_pagamento_servico_operador_dia.sql
@@ -18,6 +18,7 @@ WITH ordem_pagamento AS (
         do.id_operadora,
         do.operadora,
         r.id_linha AS id_servico_jae,
+        s.servico,
         r.id_ordem_pagamento AS id_ordem_pagamento,
         r.id_ordem_ressarcimento AS id_ordem_ressarcimento,
         r.qtd_debito AS quantidade_transacao_debito,
@@ -54,6 +55,10 @@ WITH ordem_pagamento AS (
         {{ ref("consorcios") }} AS dc
     ON
         r.id_consorcio = dc.id_consorcio_jae
+    LEFT JOIN
+        {{ ref("servicos") }} AS s
+    ON
+        r.id_linha = s.id_servico_jae
     {% if is_incremental() %}
         WHERE
             DATE(r.data) BETWEEN DATE("{{var('date_range_start')}}") AND DATE("{{var('date_range_end')}}")
@@ -66,6 +71,7 @@ SELECT
     o.id_operadora,
     o.operadora,
     o.id_servico_jae,
+    o.servico,
     o.id_ordem_pagamento,
     o.id_ordem_ressarcimento,
     o.quantidade_transacao_debito,

--- a/models/br_rj_riodejaneiro_bilhetagem/passageiros_hora.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/passageiros_hora.sql
@@ -82,6 +82,7 @@ transacao_agrupada AS (
         t.modo,
         t.consorcio,
         t.id_servico_jae,
+        t.servico,
         t.sentido,
         CASE
             WHEN i.id_integracao IS NOT NULL THEN "Integração"
@@ -128,6 +129,7 @@ transacao_tratada AS (
         t.modo,
         t.consorcio,
         t.id_servico_jae,
+        t.servico,
         t.sentido,
         CASE
             WHEN t.tipo_transacao = "Integração" THEN "Integração"

--- a/models/br_rj_riodejaneiro_bilhetagem/schema.yml
+++ b/models/br_rj_riodejaneiro_bilhetagem/schema.yml
@@ -24,8 +24,8 @@ models:
         description: "Identificador da operadora na tabela cadastro.operadoras"
       - name: operadora
         description: "Nome da operadora de transporte (mascarado se for pessoa física)"
-      # - name: servico
-      #   description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...)"
+      - name: servico
+        description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...) ou código da estação"
       - name: id_servico_jae
         description: "Identificador da linha no banco de dados da jaé (É possível cruzar os dados com a tabela rj-smtr.cadastro.servicos usando a coluna id_servico_jae)"
       - name: sentido
@@ -93,8 +93,8 @@ models:
         description: "Identificador da operadora na tabela cadastro.operadoras"
       - name: operadora
         description: "Nome da operadora de transporte (mascarado se for pessoa física)"
-      # - name: servico
-      #   description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...)"
+      - name: servico
+        description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...) ou código da estação"
       - name: id_servico_jae
         description: "Identificador da linha no banco de dados da jaé (É possível cruzar os dados com a tabela rj-smtr.cadastro.servicos usando a coluna id_servico_jae)"
       - name: id_transacao
@@ -150,7 +150,7 @@ models:
       - name: operadora
         description: "Nome da operadora de transporte (mascarado se for pessoa física)"
       - name: servico
-        description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...)"
+        description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...) ou código da estação"
       - name: id_validador
         description: "Número de série do validador"
       - name: id_transmissao_gps
@@ -394,6 +394,8 @@ models:
         description: "Nome da operadora de transporte (mascarado se for pessoa física)"
       - name: id_servico_jae
         description: "Identificador da linha no banco de dados da jaé (É possível cruzar os dados com a tabela rj-smtr.cadastro.servicos usando a coluna id_servico_jae)"
+      - name: servico
+        description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...) ou código da estação"
       - name: id_ordem_pagamento
         description: "Identificador da ordem pagamento no banco de dados da Jaé"
       - name: id_ordem_ressarcimento

--- a/models/br_rj_riodejaneiro_bilhetagem/transacao.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/transacao.sql
@@ -105,6 +105,7 @@ SELECT
     do.id_operadora,
     do.operadora,
     t.cd_linha AS id_servico_jae,
+    s.servico,
     sentido,
     CASE
       WHEN m.modo = "VLT" THEN SUBSTRING(t.veiculo_id, 1, 3)
@@ -140,6 +141,10 @@ LEFT JOIN
     {{ ref("consorcios") }} AS dc
 ON
     t.cd_consorcio = dc.id_consorcio_jae
+LEFT JOIN
+    {{ ref("servicos") }} AS s
+ON
+    t.cd_linha = s.id_servico_jae
 LEFT JOIN
     tipo_transacao AS tt
 ON

--- a/models/br_rj_riodejaneiro_bilhetagem_staging/gps_validador_aux.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem_staging/gps_validador_aux.sql
@@ -12,7 +12,8 @@ SELECT
     g.timestamp_captura AS datetime_captura,
     do.id_operadora,
     do.operadora,
-    l.nr_linha AS servico,
+    g.codigo_linha_veiculo AS id_servico_jae,
+    s.servico,
     prefixo_veiculo AS id_veiculo,
     g.numero_serie_equipamento AS id_validador,
     g.id AS id_transmissao_gps,
@@ -28,6 +29,6 @@ LEFT JOIN
 ON
     g.codigo_operadora = do.id_operadora_jae
 LEFT JOIN
-    {{ ref("staging_linha") }} AS l
+    {{ ref("servicos") }} AS s
 ON
-    g.codigo_linha_veiculo = l.cd_linha
+    g.codigo_linha_veiculo = s.id_servico_jae

--- a/models/validacao_dados_jae/ordem_pagamento_validacao.sql
+++ b/models/validacao_dados_jae/ordem_pagamento_validacao.sql
@@ -19,7 +19,6 @@ WITH servico_operador_dia_validacao AS (
   {% if is_incremental() %}
     WHERE
       data_ordem = DATE("{{var('run_date')}}")
-      -- data_ordem BETWEEN DATE("{{var('date_range_start')}}") AND DATE("{{var('date_range_end')}}")
   {% endif %}
   GROUP BY
     1,
@@ -35,7 +34,6 @@ consorcio_operador_dia_validacao AS (
   {% if is_incremental() %}
     WHERE
       data_ordem = DATE("{{var('run_date')}}")
-      -- data_ordem BETWEEN DATE("{{var('date_range_start')}}") AND DATE("{{var('date_range_end')}}")
   {% endif %}
   GROUP BY
     1,

--- a/models/validacao_dados_jae/transacao_invalida.sql
+++ b/models/validacao_dados_jae/transacao_invalida.sql
@@ -22,7 +22,7 @@ WITH transacao AS (
     t.id_operadora,
     t.operadora,
     t.id_servico_jae,
-    s.servico,
+    t.servico,
     s.descricao_servico,
     t.id_transacao,
     t.longitude,
@@ -34,9 +34,6 @@ WITH transacao AS (
     s.id_servico_gtfs
   FROM
     {{ ref("transacao") }} t
-  LEFT JOIN
-    {{ ref("servicos") }} s
-  USING (id_servico_jae)
   {% if is_incremental() %}
     WHERE 
       data = DATE_SUB(DATE("{{var('run_date')}}"), INTERVAL 1 DAY)


### PR DESCRIPTION
## Changelog
### Alterado
- Adiciona coluna `servico` nos modelos:
  - bilhetagem.transacao
  - bilhetagem.integracao
  - bilhetagem.ordem_pagamento_servico_operador_dia
  - bilhetagem.passageiros_hora
- Adiciona coluna `id_servico_jae` nos modelos:
  - bilhetagem.gps_validador
  - bilhetagem.gps_validador_van
- Muda tratamento da coluna `servico` no modelo `bilhetagem_staging.gps_validador_aux` para pegar o dado da tabela de cadastro 
- Muda tratamento do modelo `validacao_dados_jae.transacao_invalida` para pegar a coluna `servico` da tabela transacao
 ### Corrigido
- Remove comentários do modelo `validacao_dados_jae.ordem_pagamento_validacao`
