### PR TITLE
Hotfix: Corrige apontamento da tabela de `parametros_km` do encontro de contas

### DIFF
--- a/models/br_rj_riodejaneiro_rdo/CHANGELOG.md
+++ b/models/br_rj_riodejaneiro_rdo/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## [1.0.0] - 2024-05-21
 
-### Alterado
+### Adicionado
 
-- Altera referências dos modelos (https://github.com/prefeitura-rio/queries-rj-smtr/pull/319)
+- Adiciona modelo `rdo40_registros.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/319)

--- a/models/br_rj_riodejaneiro_rdo/CHANGELOG.md
+++ b/models/br_rj_riodejaneiro_rdo/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - br_rj_riodejaneiro_rdo
+
+## [1.0.0] - 2024-05-21
+
+### Alterado
+
+- Altera referências dos modelos (https://github.com/prefeitura-rio/queries-rj-smtr/pull/319)

--- a/models/br_rj_riodejaneiro_rdo/rdo40_registros.sql
+++ b/models/br_rj_riodejaneiro_rdo/rdo40_registros.sql
@@ -1,0 +1,27 @@
+WITH
+  consorcios AS (
+  SELECT
+    id_consorcio,
+    case when id_consorcio = "221000050" then "Consórcio BRT" else consorcio end as consorcio
+  FROM
+    rj-smtr.cadastro.consorcios )
+SELECT
+  data,
+  ano,
+  mes,
+  dia,
+  id_consorcio,
+  consorcio,
+  linha AS servico,
+  r.* EXCEPT(data,
+    ano,
+    mes,
+    dia,
+    termo),
+  (qtd_grt_idoso + qtd_grt_especial + qtd_grt_estud_federal + qtd_grt_estud_estadual + qtd_grt_estud_municipal + qtd_grt_rodoviario + qtd_buc_1_perna + qtd_buc_2_perna_integracao + qtd_buc_supervia_1_perna + qtd_buc_supervia_2_perna_integracao + qtd_cartoes_perna_unica_e_demais + qtd_pagamentos_especie + qtd_grt_passe_livre_universitario) AS qtd_passageiros_total
+FROM
+  {{ source("br_rj_riodejaneiro_rdo", "rdo40_tratado") }} r
+LEFT JOIN
+  consorcios c
+ON
+  r.termo = c.id_consorcio

--- a/models/br_rj_riodejaneiro_rdo/rdo40_registros.sql
+++ b/models/br_rj_riodejaneiro_rdo/rdo40_registros.sql
@@ -4,7 +4,8 @@ WITH
     id_consorcio,
     case when id_consorcio = "221000050" then "Consórcio BRT" else consorcio end as consorcio
   FROM
-    rj-smtr.cadastro.consorcios )
+    -- rj-smtr.cadastro.consorcios
+    {{ ref("consorcios") }} )
 SELECT
   data,
   ano,

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## [1.0.0] - 2024-05-21
 
-### Adicionado
+### Alterado
 
-- Adiciona modelo `rdo40_registros.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/319)
+- Altera referências dos modelos (https://github.com/prefeitura-rio/queries-rj-smtr/pull/319)

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - projeto_subsidio_sppo_encontro_contas
+
+## [1.0.0] - 2024-05-21
+
+### Adicionado
+
+- Adiciona modelo `rdo40_registros.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/319)

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -1,7 +1,22 @@
 # Changelog - projeto_subsidio_sppo_encontro_contas
 
-## [1.0.0] - 2024-05-21
+## [1.0.2] - 2024-05-21
 
 ### Alterado
 
-- Altera referências dos modelos (https://github.com/prefeitura-rio/queries-rj-smtr/pull/319)
+- Adiciona refs e sources de modelos do dbt (https://github.com/prefeitura-rio/queries-rj-smtr/pull/319)
+
+## [1.0.1] - 2024-05-16
+
+### Alterado
+
+- Refatora nome de colunas e adiciona schema.yml (https://github.com/prefeitura-rio/queries-rj-smtr/pull/306)
+
+## [1.0.0] - 2024-05-14
+
+### Adicionado
+
+- Adiciona tabela de cálculo do encontro de contas por dia e serviço + agregações (https://github.com/prefeitura-rio/queries-rj-smtr/pull/304)
+
+### Removido
+- Versões de teste: https://github.com/prefeitura-rio/queries-rj-smtr/pull/234, https://github.com/prefeitura-rio/queries-rj-smtr/pull/233

--- a/models/projeto_subsidio_sppo_encontro_contas/aux_balanco_rdo_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/aux_balanco_rdo_servico_dia.sql
@@ -14,7 +14,8 @@ WITH
     servico,
     SUM(valor_pago) AS valor_pago
   FROM
-    `rj-smtr`.`br_rj_riodejaneiro_recursos`.`recursos_sppo_servico_dia_pago`
+    {{ ref("recursos_sppo_servico_dia_pago") }}
+    -- `rj-smtr`.`br_rj_riodejaneiro_recursos`.`recursos_sppo_servico_dia_pago`
   GROUP BY
     1,
     2,
@@ -54,7 +55,8 @@ rdo AS (
     ordem_servico,
     round(SUM(receita_buc) + SUM(receita_buc_supervia) + SUM(receita_cartoes_perna_unica_e_demais) + SUM(receita_especie), 0) AS receita_tarifaria_aferida
   FROM
-    `rj-smtr`.`br_rj_riodejaneiro_rdo`.`rdo40_registros`
+    {{ ref("rdo40_registros") }}
+    -- `rj-smtr`.`br_rj_riodejaneiro_rdo`.`rdo40_registros`
   WHERE
     DATA BETWEEN "2022-06-01" AND "2023-12-31"
     AND DATA NOT IN ("2022-10-02", "2022-10-30", '2023-02-07', '2023-02-08', '2023-02-10', '2023-02-13', '2023-02-17', '2023-02-18', '2023-02-19', '2023-02-20', '2023-02-21', '2023-02-22')
@@ -71,7 +73,8 @@ sumario_dia AS (
     SUM(km_apurada) AS km_subsidiada,
     sum(valor_subsidio_pago) as subsidio_pago
   FROM
-    `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
+    {{ ref("sumario_servico_dia_historico") }}
+    -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
   WHERE
     DATA BETWEEN "2022-06-01"
     AND "2023-12-31"

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
@@ -9,7 +9,8 @@ WITH
     servico,
     SUM(valor_pago) AS valor_pago
   FROM
-    `rj-smtr`.`br_rj_riodejaneiro_recursos`.`recursos_sppo_servico_dia_pago`
+    {{ ref("recursos_sppo_servico_dia_pago") }}
+    -- `rj-smtr`.`br_rj_riodejaneiro_recursos`.`recursos_sppo_servico_dia_pago`
   GROUP BY
     1,
     2,
@@ -42,7 +43,8 @@ sumario_dia AS (  -- Km apurada por servico e dia
     SUM(km_apurada) AS km_subsidiada,
     sum(valor_subsidio_pago) as subsidio_pago
   FROM
-    `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
+    {{ ref("sumario_servico_dia_historico") }}
+    -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
   WHERE
     DATA BETWEEN "2022-06-01"
     AND "2023-12-31"
@@ -57,7 +59,8 @@ sumario_dia AS (  -- Km apurada por servico e dia
     servico,
     SUM(distancia_planejada) AS km_subsidiada
   FROM
-    `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
+    {{ ref("viagens_remuneradas") }}
+    -- `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
   WHERE
     DATA BETWEEN "2023-09-16"
     AND "2023-12-31"
@@ -103,7 +106,8 @@ rdo AS (
     AS servico,
     round(SUM(receita_buc) + SUM(receita_buc_supervia) + SUM(receita_cartoes_perna_unica_e_demais) + SUM(receita_especie), 0) AS receita_tarifaria_aferida
   FROM
-    `rj-smtr`.`br_rj_riodejaneiro_rdo`.`rdo40_registros`
+    {{ ref("rdo40_registros") }}
+    -- `rj-smtr`.`br_rj_riodejaneiro_rdo`.`rdo40_registros`
   WHERE
     DATA BETWEEN "2022-06-01" AND "2023-12-31"
     AND DATA NOT IN ("2022-10-02", "2022-10-30", '2023-02-07', '2023-02-08', '2023-02-10', '2023-02-13', '2023-02-17', '2023-02-18', '2023-02-19', '2023-02-20', '2023-02-21', '2023-02-22')
@@ -120,7 +124,7 @@ parametros as (
       else coalesce(irk_tarifa_publica, irk - (subsidio_km + desconto_subsidio_km)) end as irk_tarifa_publica,
     (subsidio_km + desconto_subsidio_km) as subsidio_km
   FROM
-    `rj-smtr.projeto_subsidio_sppo_encontro_contas.parametros_km`
+    {{ source("projeto_subsidio_sppo_encontro_contas", "parametros_km") }}
   where data_inicio >= "2022-06-01" and data_fim <= "2023-12-31"
 )
   select

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
@@ -120,7 +120,7 @@ parametros as (
       else coalesce(irk_tarifa_publica, irk - (subsidio_km + desconto_subsidio_km)) end as irk_tarifa_publica,
     (subsidio_km + desconto_subsidio_km) as subsidio_km
   FROM
-    `rj-smtr.projeto_subsidio_sppo_encontro_contas_jan_24.subsidio_parametros_atualizada` -- TODO: mover tabela para dataset correto
+    `rj-smtr.projeto_subsidio_sppo_encontro_contas.parametros_km`
   where data_inicio >= "2022-06-01" and data_fim <= "2023-12-31"
 )
   select


### PR DESCRIPTION
## Changelog
- Corrige apontamento da tabela de parâmetros para a `projeto_subsidio_sppo_encontro_contas.parametros_km`. Estava apontando para a tabela de um dataset de teste.

TODO:
- [x] Adicionar tabela como source 
- [x] Trocar demais tabelas hardcode do dataset para refs