### PR TITLE
Corrige tratamento da coluna `tipo_os` do modelo `ordem_servico_trajeto_alternativo_gtfs.sql`

### DIFF
--- a/models/gtfs/CHANGELOG.md
+++ b/models/gtfs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog - gtfs
 
+## [1.1.1] - 2024-05-21
+
+### Adicionado
+
+- Adiciona coluna `tipo_os` no modelo `ordem_servico_trajeto_alternativo_gtfs.sql`
+
+### Corrigido
+
+- Corrige tratamento da coluna `tipo_os` do modelo `ordem_servico_gtfs.sql`
+
 ## [1.1.0] - 2024-05-13
 
 ### Alterado

--- a/models/gtfs/CHANGELOG.md
+++ b/models/gtfs/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Adicionado
 
-- Adiciona coluna `tipo_os` no modelo `ordem_servico_trajeto_alternativo_gtfs.sql`
+- Adiciona coluna `tipo_os` no modelo `ordem_servico_trajeto_alternativo_gtfs.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/318)
 
 ### Corrigido
 
-- Corrige tratamento da coluna `tipo_os` do modelo `ordem_servico_gtfs.sql`
+- Corrige tratamento da coluna `tipo_os` do modelo `ordem_servico_gtfs.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/318)
 
 ## [1.1.0] - 2024-05-13
 

--- a/models/gtfs/CHANGELOG.md
+++ b/models/gtfs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog - gtfs
 
+## [1.1.2] - 2024-05-21
+
+### Adicionado
+
+- Adiciona coluna `tipo_os` no `schema.yml` em relação ao modelo `ordem_servico_trajeto_alternativo_gtfs.sql` ()
+
+### Corrigido
+
+- Corrige tratamento da coluna `tipo_os` do modelo `ordem_servico_trajeto_alternativo_gtfs.sql` ()
+
 ## [1.1.1] - 2024-05-21
 
 ### Adicionado

--- a/models/gtfs/ordem_servico_gtfs.sql
+++ b/models/gtfs/ordem_servico_gtfs.sql
@@ -11,6 +11,7 @@ WITH ordem_servico AS (
     fi.feed_version,
     SAFE_CAST(os.data_versao AS DATE) as feed_start_date,
     fi.feed_end_date,
+    COALESCE(SAFE_CAST(tipo_os) AS STRING), "Regular") tipo_os,
     SAFE_CAST(os.servico AS STRING) servico,
     SAFE_CAST(JSON_VALUE(os.content, '$.vista') AS STRING) vista,
     SAFE_CAST(JSON_VALUE(os.content, '$.consorcio') AS STRING) consorcio,
@@ -34,7 +35,6 @@ WITH ordem_servico AS (
     SAFE_CAST(SAFE_CAST(JSON_VALUE(os.content, '$.partidas_volta_domingo') AS FLOAT64) AS INT64) partidas_volta_domingo,
     SAFE_CAST(JSON_VALUE(os.content, '$.viagens_domingo') AS FLOAT64) viagens_domingo,
     SAFE_CAST(JSON_VALUE(os.content, '$.km_domingo') AS FLOAT64) km_domingo,
-    COALESCE(SAFE_CAST(JSON_VALUE(os.content, '$.tipo_os') AS STRING), "Regular") tipo_os,
   FROM 
     {{ source(
       'br_rj_riodejaneiro_gtfs_staging',

--- a/models/gtfs/ordem_servico_gtfs.sql
+++ b/models/gtfs/ordem_servico_gtfs.sql
@@ -11,7 +11,7 @@ WITH ordem_servico AS (
     fi.feed_version,
     SAFE_CAST(os.data_versao AS DATE) as feed_start_date,
     fi.feed_end_date,
-    COALESCE(SAFE_CAST(tipo_os) AS STRING), "Regular") tipo_os,
+    SAFE_CAST(tipo_os AS STRING) tipo_os,
     SAFE_CAST(os.servico AS STRING) servico,
     SAFE_CAST(JSON_VALUE(os.content, '$.vista') AS STRING) vista,
     SAFE_CAST(JSON_VALUE(os.content, '$.consorcio') AS STRING) consorcio,

--- a/models/gtfs/ordem_servico_trajeto_alternativo_gtfs.sql
+++ b/models/gtfs/ordem_servico_trajeto_alternativo_gtfs.sql
@@ -42,6 +42,7 @@ SELECT
   feed_version,
   feed_start_date,
   feed_end_date,
+  tipo_os,
   servico,
   consorcio,
   vista,

--- a/models/gtfs/ordem_servico_trajeto_alternativo_gtfs.sql
+++ b/models/gtfs/ordem_servico_trajeto_alternativo_gtfs.sql
@@ -14,6 +14,7 @@ WITH ordem_servico_trajeto_alternativo AS (
     fi.feed_version,
     SAFE_CAST(o.data_versao AS DATE) feed_start_date,
     fi.feed_end_date,
+    COALESCE(SAFE_CAST(tipo_os) AS STRING), "Regular") tipo_os,
     SAFE_CAST(o.servico AS STRING) servico,
     SAFE_CAST(JSON_VALUE(o.content, "$.ativacao") AS STRING) ativacao,
     SAFE_CAST(JSON_VALUE(o.content, "$.consorcio") AS STRING) consorcio,

--- a/models/gtfs/ordem_servico_trajeto_alternativo_gtfs.sql
+++ b/models/gtfs/ordem_servico_trajeto_alternativo_gtfs.sql
@@ -14,7 +14,7 @@ WITH ordem_servico_trajeto_alternativo AS (
     fi.feed_version,
     SAFE_CAST(o.data_versao AS DATE) feed_start_date,
     fi.feed_end_date,
-    COALESCE(SAFE_CAST(tipo_os) AS STRING), "Regular") tipo_os,
+    SAFE_CAST(tipo_os AS STRING) tipo_os,
     SAFE_CAST(o.servico AS STRING) servico,
     SAFE_CAST(JSON_VALUE(o.content, "$.ativacao") AS STRING) ativacao,
     SAFE_CAST(JSON_VALUE(o.content, "$.consorcio") AS STRING) consorcio,

--- a/models/gtfs/schema.yml
+++ b/models/gtfs/schema.yml
@@ -434,6 +434,8 @@ models:
         description: "Horário final de funcionamento do trajeto alternativo."
       - name: versao_modelo
         description: "Código de controle de versão (SHA do GitHub)."
+      - name: tipo_os
+        description: "Tipo de Ordem de Serviço (ex: 'Regular', 'Extraordinária - Verão')"
   - name: ordem_servico_trips_shapes_gtfs
     description: "Junção da Ordem de Serviço (OS) com trips e shapes dos serviços"
     columns:


### PR DESCRIPTION
# Changelog - gtfs

## [1.1.2] - 2024-05-21

### Adicionado

- Adiciona coluna `tipo_os` no `schema.yml` em relação ao modelo `ordem_servico_trajeto_alternativo_gtfs.sql`

### Corrigido

- Corrige tratamento da coluna `tipo_os` do modelo `ordem_servico_trajeto_alternativo_gtfs.sql`