### PR TITLE
Hotfix - Corrige atualização da coluna feed_end_date nas tabelas do GTFS

### DIFF
--- a/macros/get_last_feed_start_date.sql
+++ b/macros/get_last_feed_start_date.sql
@@ -1,0 +1,3 @@
+{% macro get_last_feed_start_date(data_versao_gtfs) %}
+  {{ return(run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ "'" ~ data_versao_gtfs ~ "'").columns[0].values()[0]) }}
+{% endmacro %}

--- a/models/gtfs/CHANGELOG.md
+++ b/models/gtfs/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog - gtfs
 
+## [1.1.3] - 2024-05-21
+
+### Corrigido
+- Corrige atualização incremental da coluna `feed_end_date` nos modelos (https://github.com/prefeitura-rio/queries-rj-smtr/pull/321):
+  - `agency_gtfs.sql`
+  - `calendar_dates_gtfs.sql`
+  - `fare_attributes_gtfs.sql`
+  - `fare_rules_gtfs.sql`
+  - `frequencies_gtfs.sql`
+  - `routes_gtfs.sql`
+  - `shapes_geom_gtfs.sql`
+  - `shapes_gtfs.sql`
+  - `stop_times_gtfs.sql`
+  - `stops_gtfs.sql`
+  - `trips_gtfs.sql`
+
+
 ## [1.1.2] - 2024-05-21
 
 ### Adicionado

--- a/models/gtfs/agency_gtfs.sql
+++ b/models/gtfs/agency_gtfs.sql
@@ -7,8 +7,7 @@
 ) }} 
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 SELECT 

--- a/models/gtfs/agency_gtfs.sql
+++ b/models/gtfs/agency_gtfs.sql
@@ -6,6 +6,10 @@
   alias = 'agency'
 ) }} 
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
 
 SELECT 
   fi.feed_version,
@@ -25,6 +29,6 @@ ON
   a.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
   WHERE 
-    a.data_versao = '{{ var("data_versao_gtfs") }}'
-    AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+    a.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+    AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/calendar_dates_gtfs.sql
+++ b/models/gtfs/calendar_dates_gtfs.sql
@@ -7,8 +7,7 @@
 ) }}
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 

--- a/models/gtfs/calendar_dates_gtfs.sql
+++ b/models/gtfs/calendar_dates_gtfs.sql
@@ -6,6 +6,11 @@
     alias = 'calendar_dates'
 ) }}
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
+
 
 SELECT  
   fi.feed_version,
@@ -26,6 +31,6 @@ ON
   cd.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
   WHERE 
-    cd.data_versao = '{{ var("data_versao_gtfs") }}'
-    AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+    cd.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+    AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/calendar_gtfs.sql
+++ b/models/gtfs/calendar_gtfs.sql
@@ -6,6 +6,10 @@
     alias = 'calendar'
 )}} 
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
 
 SELECT 
   fi.feed_version,
@@ -32,6 +36,6 @@ ON
   c.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
   WHERE 
-    c.data_versao = '{{ var("data_versao_gtfs") }}'
-    AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+    c.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+    AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/calendar_gtfs.sql
+++ b/models/gtfs/calendar_gtfs.sql
@@ -7,8 +7,7 @@
 )}} 
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 SELECT 

--- a/models/gtfs/fare_attributes_gtfs.sql
+++ b/models/gtfs/fare_attributes_gtfs.sql
@@ -6,6 +6,10 @@
     alias = 'fare_attributes'
 )}} 
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
 
 SELECT 
   fi.feed_version,
@@ -30,6 +34,6 @@ ON
   fa.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
   WHERE 
-    fa.data_versao = '{{ var("data_versao_gtfs") }}'
-    AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+    fa.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+    AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/fare_attributes_gtfs.sql
+++ b/models/gtfs/fare_attributes_gtfs.sql
@@ -7,8 +7,7 @@
 )}} 
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 SELECT 

--- a/models/gtfs/fare_rules_gtfs.sql
+++ b/models/gtfs/fare_rules_gtfs.sql
@@ -6,6 +6,10 @@
     alias = 'fare_rules'
 )}} 
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
 
 SELECT
   fi.feed_version,
@@ -28,6 +32,6 @@ ON
   fr.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
   WHERE 
-    fr.data_versao = '{{ var("data_versao_gtfs") }}'
-    AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+    fr.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+    AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/fare_rules_gtfs.sql
+++ b/models/gtfs/fare_rules_gtfs.sql
@@ -7,8 +7,7 @@
 )}} 
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 SELECT

--- a/models/gtfs/frequencies_gtfs.sql
+++ b/models/gtfs/frequencies_gtfs.sql
@@ -6,6 +6,10 @@
     alias = 'frequencies'
 )}} 
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
 
 SELECT 
   fi.feed_version,  
@@ -25,6 +29,6 @@ ON
   f.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
   WHERE 
-    f.data_versao = '{{ var("data_versao_gtfs") }}'
-    AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+    f.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+    AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/frequencies_gtfs.sql
+++ b/models/gtfs/frequencies_gtfs.sql
@@ -7,8 +7,7 @@
 )}} 
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 SELECT 

--- a/models/gtfs/routes_gtfs.sql
+++ b/models/gtfs/routes_gtfs.sql
@@ -6,6 +6,10 @@
     alias = 'routes'
 )}} 
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
 
 SELECT   
   fi.feed_version,
@@ -36,6 +40,6 @@ ON
   r.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
   WHERE 
-    r.data_versao = '{{ var("data_versao_gtfs") }}'
-    AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+    r.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+    AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/routes_gtfs.sql
+++ b/models/gtfs/routes_gtfs.sql
@@ -7,8 +7,7 @@
 )}} 
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 SELECT   

--- a/models/gtfs/shapes_geom_gtfs.sql
+++ b/models/gtfs/shapes_geom_gtfs.sql
@@ -6,6 +6,9 @@
     alias = 'shapes_geom'
 ) }} 
 
+{% if execute and is_incremental() %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
+{% endif %}
 
 WITH contents AS (
     SELECT 
@@ -15,7 +18,7 @@ WITH contents AS (
         feed_start_date,
     FROM {{ref('shapes_gtfs')}} s
     {% if is_incremental() -%}
-        WHERE feed_start_date = '{{ var("data_versao_gtfs") }}'
+        WHERE feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
     {%- endif %}
 ),
 pts AS (
@@ -138,5 +141,5 @@ USING
     (feed_start_date)
 {% if is_incremental() -%}
 WHERE
-    fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+    fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/shapes_gtfs.sql
+++ b/models/gtfs/shapes_gtfs.sql
@@ -7,8 +7,7 @@
 )}}
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 SELECT 

--- a/models/gtfs/shapes_gtfs.sql
+++ b/models/gtfs/shapes_gtfs.sql
@@ -6,6 +6,10 @@
     alias = 'shapes'
 )}}
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
 
 SELECT 
   fi.feed_version,
@@ -25,6 +29,6 @@ ON
   s.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
   WHERE 
-    s.data_versao = '{{ var("data_versao_gtfs") }}'
-    AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+    s.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+    AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/stop_times_gtfs.sql
+++ b/models/gtfs/stop_times_gtfs.sql
@@ -7,8 +7,7 @@
 )}} 
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 SELECT 

--- a/models/gtfs/stop_times_gtfs.sql
+++ b/models/gtfs/stop_times_gtfs.sql
@@ -6,6 +6,10 @@
     alias = 'stop_times'
 )}} 
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
 
 SELECT 
     fi.feed_version,
@@ -35,6 +39,6 @@ ON
     st.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
     WHERE 
-        st.data_versao = '{{ var("data_versao_gtfs") }}'
-        AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+        st.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+        AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/stops_gtfs.sql
+++ b/models/gtfs/stops_gtfs.sql
@@ -7,8 +7,7 @@
 )}} 
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 SELECT 

--- a/models/gtfs/stops_gtfs.sql
+++ b/models/gtfs/stops_gtfs.sql
@@ -6,6 +6,10 @@
     alias = 'stops'
 )}} 
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
 
 SELECT 
     fi.feed_version,
@@ -38,6 +42,6 @@ ON
     s.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
     WHERE 
-        s.data_versao = '{{ var("data_versao_gtfs") }}'
-        AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+        s.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+        AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}

--- a/models/gtfs/trips_gtfs.sql
+++ b/models/gtfs/trips_gtfs.sql
@@ -7,8 +7,7 @@
 )}}
 
 {% if execute and is_incremental() %}
-  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
-  {% set last_feed_version = results.columns[0].values()[0] %}
+  {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
 {% endif %}
 
 SELECT 

--- a/models/gtfs/trips_gtfs.sql
+++ b/models/gtfs/trips_gtfs.sql
@@ -6,6 +6,10 @@
     alias = 'trips'
 )}}
 
+{% if execute and is_incremental() %}
+  {% set results = run_query("SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date < " ~ '{{ var("data_versao_gtfs") }}') %}
+  {% set last_feed_version = results.columns[0].values()[0] %}
+{% endif %}
 
 SELECT 
     fi.feed_version,
@@ -33,6 +37,6 @@ ON
     t.data_versao = CAST(fi.feed_start_date AS STRING)
 {% if is_incremental() -%}
     WHERE 
-        t.data_versao = '{{ var("data_versao_gtfs") }}'
-    AND fi.feed_start_date = '{{ var("data_versao_gtfs") }}'
+        t.data_versao IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
+        AND fi.feed_start_date IN ('{{ last_feed_version }}', '{{ var("data_versao_gtfs") }}')
 {%- endif %}


### PR DESCRIPTION
# ChangeLog - gtfs
## [1.1.3] - 2024-05-21

### Corrigido
- Corrige atualização incremental da coluna `feed_end_date` nos modelos:
  - `agency_gtfs.sql`
  - `calendar_dates_gtfs.sql`
  - `fare_attributes_gtfs.sql`
  - `fare_rules_gtfs.sql`
  - `frequencies_gtfs.sql`
  - `routes_gtfs.sql`
  - `shapes_geom_gtfs.sql`
  - `shapes_gtfs.sql`
  - `stop_times_gtfs.sql`
  - `stops_gtfs.sql`
  - `trips_gtfs.sql`