### PR TITLE
Bilhetagem - adiciona transações de ônibus na passageiros_hora

### DIFF
--- a/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog - bilhetagem
 
+## [1.2.2] - 2024-05-29
+
+### Modificado
+- Adiciona transações de ônibus a partir do dia `2024-04-19` no modelo `passageiros_hora.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/328)
+
 ## [1.2.1] - 2024-05-20
 
 ### Corrigido
 - Altera alias da tabela `linha_sem_ressarcimento` no modelo `transacao.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/317)
-- Corrige select servico no modelo `ordem_pagamento_servico_operador_dia.sql` ((https://github.com/prefeitura-rio/queries-rj-smtr/pull/317)
+- Corrige select servico no modelo `ordem_pagamento_servico_operador_dia.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/317)
 
 ## [1.2.0] - 2024-05-20
 

--- a/models/br_rj_riodejaneiro_bilhetagem/passageiros_hora.sql
+++ b/models/br_rj_riodejaneiro_bilhetagem/passageiros_hora.sql
@@ -110,7 +110,7 @@ transacao_agrupada AS (
         {% endif %}
         AND t.id_servico_jae NOT IN ("140", "142")
         AND t.id_operadora != "2"
-        AND (t.modo = "BRT" OR (t.modo = "VLT" AND t.data >= DATE("2024-02-24")))
+        AND (t.modo = "BRT" OR (t.modo = "VLT" AND t.data >= DATE("2024-02-24")) OR (t.modo = "Ônibus" AND t.data >= DATE("2024-04-19")))
         AND t.tipo_transacao IS NOT NULL
     GROUP BY
         1,


### PR DESCRIPTION
# Changelog - bilhetagem

## [1.2.2] - 2024-05-29

### Modificado
- Adiciona transações de ônibus a partir do dia `2024-04-19` no modelo `passageiros_hora.sql` 