### PR TITLE
adiciona feriado de corpus christi  e ponto facultativo em subsidio_data_versao_efetiva

### DIFF
--- a/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [7.0.2] - 2024-05-29
+
+### Adicionado
+
+- Adicionados feriado de Corpus Christi (2024-05-30) e Ponto Facultativo (2024-05-31) no modelo `subsidio_data_versao_efetiva` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/329)
+
 ## [7.0.1] - 2024-05-22
 
 ### Adicionado

--- a/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -65,6 +65,8 @@ WITH
         WHEN data = "2024-03-22" THEN "Ponto Facultativo" -- Ponto Facultativo - DECRETO RIO Nº 54114/2024
         WHEN data = "2024-03-28" THEN "Ponto Facultativo" -- Ponto Facultativo - DECRETO RIO Nº 54081/2024
         WHEN data = "2024-03-29" THEN "Domingo" -- Feriado de Paixão de Cristo (Sexta-feira Santa)
+        WHEN data = "2024-05-30" THEN "Domingo" -- Feriado de Corpus Christi - (Decreto Rio Nº 54525/2024)
+        WHEN data = "2024-05-31" THEN "Ponto Facultativo" -- Ponto Facultativo - (Decreto Rio Nº 54525/2024)
         WHEN EXTRACT(DAY FROM data) = 20 AND EXTRACT(MONTH FROM data) = 1 THEN "Domingo" -- Dia de São Sebastião -- Art. 8°, I - Lei Municipal nº 5146/2010
         WHEN EXTRACT(DAY FROM data) = 23 AND EXTRACT(MONTH FROM data) = 4 THEN "Domingo" -- Dia de São Jorge -- Art. 8°, II - Lei Municipal nº 5146/2010 / Lei Estadual Nº 5198/2008 / Lei Estadual Nº 5645/2010
         WHEN EXTRACT(DAY FROM data) = 20 AND EXTRACT(MONTH FROM data) = 11 THEN "Domingo" -- Aniversário de morte de Zumbi dos Palmares / Dia da Consciência Negra -- Art. 8°, IV - Lei Municipal nº 5146/2010 / Lei Estadual nº 526/1982 / Lei Estadual nº 1929/1991 / Lei Estadual nº 4007/2002 / Lei Estadual Nº 5645/2010


### PR DESCRIPTION
## Changelog
- Adicionados feriado de Corpus Christi (2024-05-30) e Ponto Facultativo (2024-05-31) no modelo `subsidio_data_versao_efetiva`

## Checklist

- [ ] Já testei os modelos no BigQuery
- [ ] Já existe pipeline no Prefect
- [ ] Título do PR está 💯

> Utilize os seguintes padrões de nomeação:
> 
> 1. Alterações em modelos: `[smtr][pipeline/dataset sem prefixo*] <fix/feat>: <descricao>`
> 2. Alterações no repositório: `[smtr][infra] <fix/feat>: <descricao>`
>
> \* Ex: br_rj_riodejaneiro_onibus_gps -> onibus_gps
