### PR TITLE
Altera tratamento do RDO no Encontro de Contas

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -176,6 +176,9 @@ vars:
   ### Diretorios ###
   ids_consorcios: {"'221000014'": "'6'", "'221000023'": "'4'", "'221000032'": "'3'", "'221000041'": "'5'", "'221000050'": "NULL", "'229000010'": "'1'"}
 
+  ### Encontro de Contas ###
+  encontro_contas_modo: ""
+
 models:
   +persist_docs:
     relation: true

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -177,7 +177,7 @@ vars:
   ids_consorcios: {"'221000014'": "'6'", "'221000023'": "'4'", "'221000032'": "'3'", "'221000041'": "'5'", "'221000050'": "NULL", "'229000010'": "'1'"}
 
   ### Encontro de Contas ###
-  encontro_contas_modo: ""
+  encontro_contas_modo: "_pre_gt"
 
 models:
   +persist_docs:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -177,7 +177,7 @@ vars:
   ids_consorcios: {"'221000014'": "'6'", "'221000023'": "'4'", "'221000032'": "'3'", "'221000041'": "'5'", "'221000050'": "NULL", "'229000010'": "'1'"}
 
   ### Encontro de Contas ###
-  encontro_contas_modo: "_pre_gt"
+  encontro_contas_modo: ""
 
 models:
   +persist_docs:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -259,6 +259,9 @@ models:
     projeto_subsidio_sppo_encontro_contas:
       +materialized: table
       +schema: projeto_subsidio_sppo_encontro_contas
+      staging:
+        +materialized: view
+        +schema: projeto_subsidio_sppo_encontro_contas_staging
     dashboard_controle_vinculo_jae_riocard:
       +materialized: incremental
       +schema: dashboard_controle_vinculo_jae_riocard

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Alterado
 
-- Altera e corrige tratamento de serviços do RDO no modelo `balanco_servico_dia.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
+- Altera e corrige tratamento de serviços do RDO nos modelos `balanco_servico_dia.sql` e `aux_balanco_rdo_servico_dia.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
 
 ## [1.0.2] - 2024-05-21
 

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog - projeto_subsidio_sppo_encontro_contas
 
-## [1.0.3] - 2024-06-04
+## [1.0.3] - 2024-06-05
 
 ### Adicionado
 
 - Adiciona modelo `staging.rdo_correcao_rioonibus_servico_quinzena.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
-- Adiciona modos de execução `_pre_gt` e `_pos_gt` e as respectivas alterações dos nomes das tabelas (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
+- Adiciona modos de execução `_pre_gt` (antes das alterações do Grupo de Trabalho) e `_pos_gt` (após as alterações do Grupo de Trabalho) conforme Processo Rio MTR-PRO-2024/06270 e as respectivas alterações dos nomes das tabelas (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
 
 ### Alterado
 

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Adicionado
 
 - Adiciona modelo `staging.rdo_correcao_rioonibus_servico_quinzena.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
+- Adiciona modos de execução `pre_gt` e `pos_gt` e alteração do nome da tabela (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
 
 ### Alterado
 

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -1,15 +1,12 @@
 # Changelog - projeto_subsidio_sppo_encontro_contas
 
-## [1.0.3] - 2024-06-05
+## [1.0.3] - 2024-06-07
 
 ### Adicionado
 
 - Adiciona modelo `staging.rdo_correcao_rioonibus_servico_quinzena.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
-- Adiciona modos de execução `_pre_gt` (antes das alterações do Grupo de Trabalho) e `_pos_gt` (após as alterações do Grupo de Trabalho) conforme Processo Rio MTR-PRO-2024/06270 e as respectivas alterações dos nomes das tabelas (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
-
-### Alterado
-
-- Altera e corrige tratamento de serviços do RDO no modelo `balanco_servico_dia.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
+- Adiciona modos de execução `""` (antes das alterações do Grupo de Trabalho) e `"_pos_gt"` (após as alterações do Grupo de Trabalho) conforme Processo.Rio MTR-PRO-2024/06270 e as respectivas alterações dos nomes das tabelas (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
+- Adiciona novo tratamento de serviços do RDO no modelo `balanco_servico_dia_pos_gt.sql` com base no modelo `balanco_servico_dia.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
 
 ## [1.0.2] - 2024-05-21
 

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adicionado
 
 - Adiciona modelo `staging.rdo_correcao_rioonibus_servico_quinzena.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
-- Adiciona modos de execução `pre_gt` e `pos_gt` e alteração do nome da tabela (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
+- Adiciona modos de execução `_pre_gt` e `_pos_gt` e as respectivas alterações dos nomes das tabelas (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
 
 ### Alterado
 

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Adiciona modelo `staging.rdo_correcao_rioonibus_servico_quinzena.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
 - Adiciona modos de execução `""` (antes das alterações do Grupo de Trabalho) e `"_pos_gt"` (após as alterações do Grupo de Trabalho) conforme Processo.Rio MTR-PRO-2024/06270 e as respectivas alterações dos nomes das tabelas (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
 - Adiciona novo tratamento de serviços do RDO no modelo `balanco_servico_dia_pos_gt.sql` com base no modelo `balanco_servico_dia.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
+- Adiciona e altera descrições no schema.yml dos modelos (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
 
 ## [1.0.2] - 2024-05-21
 

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Alterado
 
-- Altera e corrige tratamento de serviços do RDO nos modelos `balanco_servico_dia.sql` e `aux_balanco_rdo_servico_dia.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
+- Altera e corrige tratamento de serviços do RDO no modelo `balanco_servico_dia.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
 
 ## [1.0.2] - 2024-05-21
 

--- a/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo_encontro_contas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog - projeto_subsidio_sppo_encontro_contas
 
+## [1.0.3] - 2024-06-04
+
+### Adicionado
+
+- Adiciona modelo `staging.rdo_correcao_rioonibus_servico_quinzena.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
+
+### Alterado
+
+- Altera e corrige tratamento de serviços do RDO no modelo `balanco_servico_dia.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/332)
+
 ## [1.0.2] - 2024-05-21
 
 ### Alterado

--- a/models/projeto_subsidio_sppo_encontro_contas/aux_balanco_rdo_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/aux_balanco_rdo_servico_dia.sql
@@ -47,7 +47,7 @@ rdo AS (
     CASE
       WHEN LENGTH(linha) < 3 THEN LPAD(linha, 3, "0")
     ELSE
-    CONCAT( IFNULL(REGEXP_EXTRACT(linha, r"[B-Z]+"), ""), IFNULL(REGEXP_EXTRACT(linha, r"[0-9]+"), "") )
+    CONCAT( IFNULL(REGEXP_EXTRACT(linha, r"[A-Z]+"), ""), IFNULL(REGEXP_EXTRACT(linha, r"[0-9]+"), "") )
   END
     AS servico,
     linha,

--- a/models/projeto_subsidio_sppo_encontro_contas/aux_balanco_rdo_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/aux_balanco_rdo_servico_dia.sql
@@ -109,7 +109,7 @@ SELECT
   rdo.ordem_servico as ordem_servico_rdo,
   rdo.receita_tarifaria_aferida as receita_tarifaria_aferida_rdo
 FROM
-  {{ ref("balanco_servico_dia") }} bsd
+  {{ ref("balanco_servico_dia" ~ var('encontro_contas_modo')) }} bsd
 FULL JOIN
   rdo_filtrada rdo
 USING

--- a/models/projeto_subsidio_sppo_encontro_contas/aux_balanco_rdo_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/aux_balanco_rdo_servico_dia.sql
@@ -47,7 +47,7 @@ rdo AS (
     CASE
       WHEN LENGTH(linha) < 3 THEN LPAD(linha, 3, "0")
     ELSE
-    CONCAT( IFNULL(REGEXP_EXTRACT(linha, r"[A-Z]+"), ""), IFNULL(REGEXP_EXTRACT(linha, r"[0-9]+"), "") )
+    CONCAT( IFNULL(REGEXP_EXTRACT(linha, r"[B-Z]+"), ""), IFNULL(REGEXP_EXTRACT(linha, r"[0-9]+"), "") )
   END
     AS servico,
     linha,

--- a/models/projeto_subsidio_sppo_encontro_contas/aux_balanco_rdo_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/aux_balanco_rdo_servico_dia.sql
@@ -64,44 +64,6 @@ rdo AS (
     and (length(linha) != 4 and linha not like "2%") --  Remove rodoviarios
   group by 1,2,3,4,5,6
 ),
-
--- 4. Considera os serviços conforme tratamento indicado pela RioÔnibus (citar processo/ofício)
-cro AS (
-  SELECT DISTINCT
-    data_inicio_quinzena, 
-    data_final_quinzena, 
-    servico_tratado_rdo, 
-    servico_corrigido_rioonibus
-  FROM
-    {{ ref("rdo_correcao_rioonibus_servico_quinzena") }}
-),
-
--- 5. Altera os serviços conforme tratamento indicado pela RioÔnibus (citar processo/ofício)
-rdo_tratado AS (
-  SELECT
-    data,
-    consorcio,
-    COALESCE(cro.servico_corrigido_rioonibus, rdo.servico) AS servico,
-    linha,
-    tipo_servico,
-    ordem_servico,
-    SUM(receita_tarifaria_aferida) AS receita_tarifaria_aferida
-  FROM
-    rdo
-  LEFT JOIN
-    cro
-  ON
-    rdo.data BETWEEN cro.data_inicio_quinzena AND cro.data_final_quinzena
-    AND rdo.servico = cro.servico_tratado_rdo
-  GROUP BY 
-    1,
-    2,
-    3,
-    4,
-    5,
-    6
-),
-
 -- Remove servicos nao subsidiados
 sumario_dia AS (
   SELECT
@@ -124,7 +86,7 @@ sumario_dia AS (
 rdo_filtrada as (
     select rdo.* from
     (
-      select * from rdo_tratado AS rdo
+      select * from rdo
       left join servico_dia_atipico sda
       using (data, servico)
       where sda.data is null

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_ano.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_ano.sql
@@ -1,3 +1,7 @@
+{% if var("encontro_contas_modo") != "" %}
+  {{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
+{% endif %}
+
 select
   extract(year from data) as ano,
   consorcio,

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_ano.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_ano.sql
@@ -12,6 +12,6 @@ select
   sum(receita_tarifaria_aferida) as receita_tarifaria_aferida,
   sum(subsidio_pago) as subsidio_pago,
   sum(saldo) as saldo
-from {{ ref("balanco_servico_dia") }}
+from {{ ref("balanco_servico_dia" ~ var('encontro_contas_modo')) }}
 group by 1,2
 order by 1,2

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_ano.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_ano.sql
@@ -1,6 +1,4 @@
-{% if var("encontro_contas_modo") != "" %}
-  {{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
-{% endif %}
+{{ config(alias=this.name ~ var('encontro_contas_modo')) }}
 
 select
   extract(year from data) as ano,

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_dia.sql
@@ -12,6 +12,6 @@ select
   sum(receita_tarifaria_aferida) as receita_tarifaria_aferida,
   sum(subsidio_pago) as subsidio_pago,
   sum(saldo) as saldo
-from {{ ref("balanco_servico_dia") }}
+from {{ ref("balanco_servico_dia" ~ var('encontro_contas_modo')) }}
 group by 1,2
 order by 1,2

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_dia.sql
@@ -1,6 +1,4 @@
-{% if var("encontro_contas_modo") != "" %}
-  {{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
-{% endif %}
+{{ config(alias=this.name ~ var('encontro_contas_modo')) }}
 
 select
   data,

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_consorcio_dia.sql
@@ -1,3 +1,7 @@
+{% if var("encontro_contas_modo") != "" %}
+  {{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
+{% endif %}
+
 select
   data,
   consorcio,

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_ano.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_ano.sql
@@ -1,3 +1,7 @@
+{% if var("encontro_contas_modo") != "" %}
+  {{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
+{% endif %}
+
 select
   extract(year from data) as ano,
   consorcio,

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_ano.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_ano.sql
@@ -1,6 +1,4 @@
-{% if var("encontro_contas_modo") != "" %}
-  {{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
-{% endif %}
+{{ config(alias=this.name ~ var('encontro_contas_modo')) }}
 
 select
   extract(year from data) as ano,

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_ano.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_ano.sql
@@ -13,6 +13,6 @@ select
   sum(receita_tarifaria_aferida) as receita_tarifaria_aferida,
   sum(subsidio_pago) as subsidio_pago,
   sum(saldo) as saldo
-from {{ ref("balanco_servico_dia") }}
+from {{ ref("balanco_servico_dia" ~ var('encontro_contas_modo')) }}
 group by 1,2,3
 order by 1,2,3

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
@@ -10,8 +10,8 @@ WITH
     servico,
     SUM(valor_pago) AS valor_pago
   FROM
-    -- {{ ref("recursos_sppo_servico_dia_pago") }}
-    `rj-smtr`.`br_rj_riodejaneiro_recursos`.`recursos_sppo_servico_dia_pago`
+    {{ ref("recursos_sppo_servico_dia_pago") }}
+    -- `rj-smtr`.`br_rj_riodejaneiro_recursos`.`recursos_sppo_servico_dia_pago`
   GROUP BY
     1,
     2,
@@ -44,8 +44,8 @@ sumario_dia AS (  -- Km apurada por servico e dia
     SUM(km_apurada) AS km_subsidiada,
     sum(valor_subsidio_pago) as subsidio_pago
   FROM
-    -- {{ ref("sumario_servico_dia_historico") }}
-    `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
+    {{ ref("sumario_servico_dia_historico") }}
+    -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
   WHERE
     DATA BETWEEN "2022-06-01"
     AND "2023-12-31"
@@ -60,8 +60,8 @@ sumario_dia AS (  -- Km apurada por servico e dia
     servico,
     SUM(distancia_planejada) AS km_subsidiada
   FROM
-    -- {{ ref("viagens_remuneradas") }}
-    `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
+    {{ ref("viagens_remuneradas") }}
+    -- `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
   WHERE
     DATA BETWEEN "2023-09-16"
     AND "2023-12-31"
@@ -107,8 +107,8 @@ rdo AS (
     AS servico,
     round(SUM(receita_buc) + SUM(receita_buc_supervia) + SUM(receita_cartoes_perna_unica_e_demais) + SUM(receita_especie), 0) AS receita_tarifaria_aferida
   FROM
-    -- {{ ref("rdo40_registros") }}
-    `rj-smtr`.`br_rj_riodejaneiro_rdo`.`rdo40_registros`
+    {{ ref("rdo40_registros") }}
+    -- `rj-smtr`.`br_rj_riodejaneiro_rdo`.`rdo40_registros`
   WHERE
     DATA BETWEEN "2022-06-01" AND "2023-12-31"
     AND DATA NOT IN ("2022-10-02", "2022-10-30", '2023-02-07', '2023-02-08', '2023-02-10', '2023-02-13', '2023-02-17', '2023-02-18', '2023-02-19', '2023-02-20', '2023-02-21', '2023-02-22')

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
@@ -1,4 +1,4 @@
-{% if var("encontro_contas_modo") == "_pre_gt" %}
+{% if var("encontro_contas_modo") == "" %}
 -- 0. Lista servicos e dias atípicos (pagos por recurso)
 WITH
   recursos AS (

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
@@ -1,6 +1,4 @@
-{% if var("encontro_contas_modo") != "" %}
-  {{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
-{% endif %}
+{{ config(alias=this.name ~ var('encontro_contas_modo')) }}
 
 -- 0. Lista servicos e dias atípicos (pagos por recurso)
 WITH
@@ -118,7 +116,7 @@ rdo AS (
   group by 1,2,3
 ),
 
-{% if var("encontro_contas_modo") == "pos_gt" %}
+{% if var("encontro_contas_modo") == "_pos_gt" %}
 -- 4. Considera os serviços conforme tratamento indicado em resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027 (Processo MTR-PRO-2024/06270)
 rdo_correcao_servico AS (
   SELECT DISTINCT
@@ -180,7 +178,7 @@ parametros as (
     from
       km_subsidiada_filtrada ks
     left join
-      {% if var("encontro_contas_modo") == "pos_gt" %}
+      {% if var("encontro_contas_modo") == "_pos_gt" %}
       rdo_corrigido AS rdo
       {% else %}
       rdo

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
@@ -114,7 +114,7 @@ rdo AS (
   group by 1,2,3
 ),
 
--- 4. Considera os serviços conforme tratamento indicado em resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027
+-- 4. Considera os serviços conforme tratamento indicado em resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027 (Processo MTR-PRO-2024/06270)
 rdo_correcao_servico AS (
   SELECT DISTINCT
     data_inicio_quinzena, 

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
@@ -1,3 +1,7 @@
+{% if var("encontro_contas_modo") != "" %}
+  {{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
+{% endif %}
+
 -- 0. Lista servicos e dias atípicos (pagos por recurso)
 WITH
   recursos AS (
@@ -114,6 +118,7 @@ rdo AS (
   group by 1,2,3
 ),
 
+{% if var("encontro_contas_modo") == "pos_gt" %}
 -- 4. Considera os serviços conforme tratamento indicado em resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027 (Processo MTR-PRO-2024/06270)
 rdo_correcao_servico AS (
   SELECT DISTINCT
@@ -144,6 +149,7 @@ rdo_corrigido AS (
     2,
     3
 ),
+{% endif %}
 
 parametros as (
   SELECT
@@ -174,7 +180,11 @@ parametros as (
     from
       km_subsidiada_filtrada ks
     left join
+      {% if var("encontro_contas_modo") == "pos_gt" %}
       rdo_corrigido AS rdo
+      {% else %}
+      rdo
+      {% endif %}
     using 
       (data, servico, consorcio)
     left join

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia.sql
@@ -114,7 +114,7 @@ rdo AS (
   group by 1,2,3
 ),
 
--- 4. Considera os serviços conforme tratamento indicado pela RioÔnibus (citar processo/ofício)
+-- 4. Considera os serviços conforme tratamento indicado em resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027
 rdo_correcao_servico AS (
   SELECT DISTINCT
     data_inicio_quinzena, 
@@ -125,7 +125,7 @@ rdo_correcao_servico AS (
     {{ ref("rdo_correcao_rioonibus_servico_quinzena") }}
 ),
 
--- 5. Altera os serviços conforme tratamento indicado pela RioÔnibus (citar processo/ofício)
+-- 5. Corrige os serviços do RDO
 rdo_corrigido AS (
   SELECT
     data,

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia_pos_gt.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia_pos_gt.sql
@@ -38,7 +38,7 @@ WHERE
 -- 1. Calcula a km subsidiada por servico e dia
 sumario_dia AS (  -- Km apurada por servico e dia
   SELECT
-    DATA,
+    data,
     consorcio,
     servico,
     SUM(km_apurada) AS km_subsidiada,
@@ -47,7 +47,7 @@ sumario_dia AS (  -- Km apurada por servico e dia
     -- {{ ref("sumario_servico_dia_historico") }}
     `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
   WHERE
-    DATA BETWEEN "2022-06-01"
+    data BETWEEN "2022-06-01"
     AND "2023-12-31"
     and valor_subsidio_pago > 0
   GROUP BY
@@ -56,14 +56,14 @@ sumario_dia AS (  -- Km apurada por servico e dia
     3),
   viagem_remunerada AS ( -- Km subsidiada pos regra do teto de 120% por servico e dia
   SELECT
-    DATA,
+    data,
     servico,
     SUM(distancia_planejada) AS km_subsidiada
   FROM
     -- {{ ref("viagens_remuneradas") }}
     `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
   WHERE
-    DATA BETWEEN "2023-09-16"
+    data BETWEEN "2023-09-16"
     AND "2023-12-31"
     AND indicador_viagem_remunerada = TRUE -- useless
   GROUP BY
@@ -109,8 +109,8 @@ rdo AS (
     -- {{ ref("rdo40_registros") }}
     `rj-smtr`.`br_rj_riodejaneiro_rdo`.`rdo40_registros`
   WHERE
-    DATA BETWEEN "2022-06-01" AND "2023-12-31"
-    AND DATA NOT IN ("2022-10-02", "2022-10-30", '2023-02-07', '2023-02-08', '2023-02-10', '2023-02-13', '2023-02-17', '2023-02-18', '2023-02-19', '2023-02-20', '2023-02-21', '2023-02-22')
+    data BETWEEN "2022-06-01" AND "2023-12-31"
+    AND data NOT IN ("2022-10-02", "2022-10-30", '2023-02-07', '2023-02-08', '2023-02-10', '2023-02-13', '2023-02-17', '2023-02-18', '2023-02-19', '2023-02-20', '2023-02-21', '2023-02-22')
     and consorcio in ("Internorte", "Intersul", "Santa Cruz", "Transcarioca")
   group by 1,2,3
 ),

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia_pos_gt.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia_pos_gt.sql
@@ -1,0 +1,188 @@
+{% if var("encontro_contas_modo") == "_pos_gt" %}
+-- 0. Lista servicos e dias atípicos (pagos por recurso)
+WITH
+  recursos AS (
+  SELECT
+    data,
+    id_recurso,
+    tipo_recurso,
+    -- consorcio,
+    servico,
+    SUM(valor_pago) AS valor_pago
+  FROM
+    -- {{ ref("recursos_sppo_servico_dia_pago") }}
+    `rj-smtr`.`br_rj_riodejaneiro_recursos`.`recursos_sppo_servico_dia_pago`
+  GROUP BY
+    1,
+    2,
+    3,
+    4),
+servico_dia_atipico as (
+SELECT
+  DISTINCT data, servico
+FROM
+  recursos
+WHERE
+  -- Quando o valor do recurso pago for R$ 0, desconsidera-se o recurso, pois:
+    -- Recurso pode ter sido cancelado (pago e depois revertido)
+    -- Problema reporto não gerou impacto na operação (quando aparece apenas 1 vez)
+  valor_pago != 0
+  -- Desconsideram-se recursos do tipo "Algoritmo" (igual a apuração em produção, levantado pela TR/SUBTT/CMO) 
+  -- Desconsideram-se recursos do tipo "Viagem Individual" (não afeta serviço-dia)
+  AND tipo_recurso NOT IN ("Algoritmo", "Viagem Individual")
+  -- Desconsideram-se recursos de reprocessamento que já constam em produção
+  AND NOT (data BETWEEN "2022-06-01" AND "2022-06-30" 
+            AND tipo_recurso = "Reprocessamento")
+),
+
+-- 1. Calcula a km subsidiada por servico e dia
+sumario_dia AS (  -- Km apurada por servico e dia
+  SELECT
+    DATA,
+    consorcio,
+    servico,
+    SUM(km_apurada) AS km_subsidiada,
+    sum(valor_subsidio_pago) as subsidio_pago
+  FROM
+    -- {{ ref("sumario_servico_dia_historico") }}
+    `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
+  WHERE
+    DATA BETWEEN "2022-06-01"
+    AND "2023-12-31"
+    and valor_subsidio_pago > 0
+  GROUP BY
+    1,
+    2,
+    3),
+  viagem_remunerada AS ( -- Km subsidiada pos regra do teto de 120% por servico e dia
+  SELECT
+    DATA,
+    servico,
+    SUM(distancia_planejada) AS km_subsidiada
+  FROM
+    -- {{ ref("viagens_remuneradas") }}
+    `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
+  WHERE
+    DATA BETWEEN "2023-09-16"
+    AND "2023-12-31"
+    AND indicador_viagem_remunerada = TRUE -- useless
+  GROUP BY
+    1,
+    2 ),
+km_subsidiada_dia as (
+  SELECT
+  sd.* except(km_subsidiada),
+    ifnull(case when data >= "2023-09-16" then vr.km_subsidiada else sd.km_subsidiada end, 0) as km_subsidiada
+  FROM
+    sumario_dia sd
+  LEFT JOIN
+    viagem_remunerada as vr
+  using
+    (data, servico)
+),
+
+-- 2. Filtra km subsidiada apenas em dias típicos (remove servicos e dias pagos por recurso)
+km_subsidiada_filtrada as (
+  select
+    ksd.*
+  from km_subsidiada_dia ksd
+  left join servico_dia_atipico sda
+  using (data, servico)
+  where sda.data is null
+  -- Demais dias que não foi considerada a km apurada via GPS:
+  and ksd.data NOT IN ("2022-10-02", "2022-10-30", '2023-02-07', '2023-02-08', '2023-02-10', '2023-02-13', '2023-02-17', '2023-02-18', '2023-02-19', '2023-02-20', '2023-02-21', '2023-02-22')
+),
+
+-- 3. Calcula a receita tarifaria por servico e dia
+rdo AS (
+  SELECT
+    data,
+    consorcio,
+    CASE
+      WHEN LENGTH(linha) < 3 THEN LPAD(linha, 3, "0")
+    ELSE
+    CONCAT( IFNULL(REGEXP_EXTRACT(linha, r"[A-Z]+"), ""), IFNULL(REGEXP_EXTRACT(linha, r"[0-9]+"), "") )
+  END
+    AS servico,
+    SUM(receita_buc) + SUM(receita_buc_supervia) + SUM(receita_cartoes_perna_unica_e_demais) + SUM(receita_especie) AS receita_tarifaria_aferida
+  FROM
+    -- {{ ref("rdo40_registros") }}
+    `rj-smtr`.`br_rj_riodejaneiro_rdo`.`rdo40_registros`
+  WHERE
+    DATA BETWEEN "2022-06-01" AND "2023-12-31"
+    AND DATA NOT IN ("2022-10-02", "2022-10-30", '2023-02-07', '2023-02-08', '2023-02-10', '2023-02-13', '2023-02-17', '2023-02-18', '2023-02-19', '2023-02-20', '2023-02-21', '2023-02-22')
+    and consorcio in ("Internorte", "Intersul", "Santa Cruz", "Transcarioca")
+  group by 1,2,3
+),
+
+-- 4. Considera os serviços conforme tratamento indicado em resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027 (Processo MTR-PRO-2024/06270)
+rdo_correcao_servico AS (
+  SELECT DISTINCT
+    data_inicio_quinzena, 
+    data_final_quinzena, 
+    servico_tratado_rdo, 
+    servico_corrigido_rioonibus
+  FROM
+    {{ ref("rdo_correcao_rioonibus_servico_quinzena") }}
+),
+
+-- 5. Corrige os serviços do RDO
+rdo_corrigido AS (
+  SELECT
+    data,
+    consorcio,
+    COALESCE(cro.servico_corrigido_rioonibus, rdo.servico) AS servico,
+    SUM(receita_tarifaria_aferida) AS receita_tarifaria_aferida
+  FROM
+    rdo
+  LEFT JOIN
+    rdo_correcao_servico AS cro
+  ON
+    rdo.data BETWEEN cro.data_inicio_quinzena AND cro.data_final_quinzena
+    AND rdo.servico = cro.servico_tratado_rdo
+  GROUP BY 
+    1,
+    2,
+    3
+),
+
+parametros as (
+  SELECT
+    DISTINCT data_inicio,
+    data_fim,
+    irk,
+    case 
+      when data_fim <= "2022-12-31" then irk - subsidio_km  -- subsidio varia ao longo dos meses
+      else coalesce(irk_tarifa_publica, irk - (subsidio_km + desconto_subsidio_km)) end as irk_tarifa_publica,
+    (subsidio_km + desconto_subsidio_km) as subsidio_km
+  FROM
+    {{ source("projeto_subsidio_sppo_encontro_contas", "parametros_km") }}
+  where data_inicio >= "2022-06-01" and data_fim <= "2023-12-31"
+)
+  select
+    *,
+    ifnull(receita_total_aferida, 0) - ifnull(receita_total_esperada - subsidio_glosado, 0) as saldo
+  from (
+    select
+      ks.* except(subsidio_pago),
+      ks.km_subsidiada * par.irk as receita_total_esperada,
+      ks.km_subsidiada * par.irk_tarifa_publica as receita_tarifaria_esperada,
+      ks.km_subsidiada * par.subsidio_km as subsidio_esperado,
+      case when data >= "2023-01-01" then (ks.km_subsidiada * par.subsidio_km - subsidio_pago) else 0 end as subsidio_glosado,
+      ifnull(rdo.receita_tarifaria_aferida, 0) + ifnull(ks.subsidio_pago, 0) as receita_total_aferida,
+      rdo.receita_tarifaria_aferida,
+      ks.subsidio_pago
+    from
+      km_subsidiada_filtrada ks
+    left join
+      rdo_corrigido AS rdo
+    using 
+      (data, servico, consorcio)
+    left join
+      parametros par
+    on
+      ks.data between data_inicio and data_fim
+  )
+{% else %}
+{{ config(enabled=false) }}
+{% endif %}

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia_pos_gt.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_dia_pos_gt.sql
@@ -10,8 +10,8 @@ WITH
     servico,
     SUM(valor_pago) AS valor_pago
   FROM
-    -- {{ ref("recursos_sppo_servico_dia_pago") }}
-    `rj-smtr`.`br_rj_riodejaneiro_recursos`.`recursos_sppo_servico_dia_pago`
+    {{ ref("recursos_sppo_servico_dia_pago") }}
+    -- `rj-smtr`.`br_rj_riodejaneiro_recursos`.`recursos_sppo_servico_dia_pago`
   GROUP BY
     1,
     2,
@@ -44,8 +44,8 @@ sumario_dia AS (  -- Km apurada por servico e dia
     SUM(km_apurada) AS km_subsidiada,
     sum(valor_subsidio_pago) as subsidio_pago
   FROM
-    -- {{ ref("sumario_servico_dia_historico") }}
-    `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
+    {{ ref("sumario_servico_dia_historico") }}
+    -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
   WHERE
     data BETWEEN "2022-06-01"
     AND "2023-12-31"
@@ -60,8 +60,8 @@ sumario_dia AS (  -- Km apurada por servico e dia
     servico,
     SUM(distancia_planejada) AS km_subsidiada
   FROM
-    -- {{ ref("viagens_remuneradas") }}
-    `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
+    {{ ref("viagens_remuneradas") }}
+    -- `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
   WHERE
     data BETWEEN "2023-09-16"
     AND "2023-12-31"
@@ -106,8 +106,8 @@ rdo AS (
     AS servico,
     SUM(receita_buc) + SUM(receita_buc_supervia) + SUM(receita_cartoes_perna_unica_e_demais) + SUM(receita_especie) AS receita_tarifaria_aferida
   FROM
-    -- {{ ref("rdo40_registros") }}
-    `rj-smtr`.`br_rj_riodejaneiro_rdo`.`rdo40_registros`
+    {{ ref("rdo40_registros") }}
+    -- `rj-smtr`.`br_rj_riodejaneiro_rdo`.`rdo40_registros`
   WHERE
     data BETWEEN "2022-06-01" AND "2023-12-31"
     AND data NOT IN ("2022-10-02", "2022-10-30", '2023-02-07', '2023-02-08', '2023-02-10', '2023-02-13', '2023-02-17', '2023-02-18', '2023-02-19', '2023-02-20', '2023-02-21', '2023-02-22')

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_quinzena.sql
@@ -1,6 +1,4 @@
-{% if var("encontro_contas_modo") != "" %}
-  {{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
-{% endif %}
+{{ config(alias=this.name ~ var('encontro_contas_modo')) }}
 
 WITH
   q1 AS (

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_quinzena.sql
@@ -1,3 +1,7 @@
+{% if var("encontro_contas_modo") != "" %}
+  {{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
+{% endif %}
+
 WITH
   q1 AS (
   SELECT

--- a/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/balanco_servico_quinzena.sql
@@ -46,7 +46,7 @@ SELECT
 FROM
   quinzenas qz
 LEFT JOIN
-  {{ ref("balanco_servico_dia") }} bs
+  {{ ref("balanco_servico_dia" ~ var('encontro_contas_modo')) }} bs
 ON
   bs.data BETWEEN qz.data_inicial_quinzena
   AND qz.data_final_quinzena

--- a/models/projeto_subsidio_sppo_encontro_contas/receita_tarifaria_servico_nao_identificado_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/receita_tarifaria_servico_nao_identificado_quinzena.sql
@@ -1,3 +1,5 @@
+{% if var("encontro_contas_modo") == "_pre_gt" %}
+{{ config(alias=this.name ~ var('encontro_contas_modo')) }}
 WITH
   q1 AS (
   SELECT
@@ -48,3 +50,6 @@ GROUP BY
   1,2,3,4,5,6,7,8
 ORDER BY
   2,4,5,6,7,8
+{% else %}
+{{ config(enabled=false) }}
+{% endif %}

--- a/models/projeto_subsidio_sppo_encontro_contas/receita_tarifaria_servico_nao_identificado_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/receita_tarifaria_servico_nao_identificado_quinzena.sql
@@ -1,4 +1,4 @@
-{% if var("encontro_contas_modo") == "_pre_gt" %}
+{% if var("encontro_contas_modo") == "" %}
 {{ config(alias=this.name ~ var('encontro_contas_modo')) }}
 WITH
   q1 AS (

--- a/models/projeto_subsidio_sppo_encontro_contas/schema.yml
+++ b/models/projeto_subsidio_sppo_encontro_contas/schema.yml
@@ -60,6 +60,8 @@ models:
     columns:
       - name: ano
         description: "Ano"
+      - name: consorcio
+        description: "Consórcio"
       - name: servico
         description: "Serviço"
       - name: km_subsidiada
@@ -108,6 +110,34 @@ models:
         description: "Subsídio pago [R$]"
       - name: saldo
         description: "Saldo entre a receita esperada e aferida, descontado o subsídio glosado [R$]"
+  - name: balanco_servico_dia_pos_gt
+    description: "Balanço da receita aferida e esperada por servico e
+    dia para serviços-dia subsidiados após alterações do Grupo de Trabalho (Processo.Rio MTR-PRO-2024/06270). Ver metodologia em NOTA TÉCNICA TR/SUBTT Nº 01/2024 e 02/2024"
+    columns:
+      - name: data
+        description: "Data"
+      - name: consorcio
+        description: "Consórcio"
+      - name: servico
+        description: "Serviço"
+      - name: km_subsidiada
+        description: "Quilometragem apurada e subsidiada via algoritmo [km]"
+      - name: receita_total_esperada
+        description: "Receita total esperada com base na quilometragem (IRK x km) [R$]"
+      - name: receita_tarifaria_esperada
+        description: "Receita tarifária esperada com base na quilometragem [R$]"
+      - name: subsidio_esperado
+        description: "Subsídio esperado com base na quilometragem [R$]"
+      - name: subsidio_glosado
+        description: "Subsídio glosado conforme os decretos e resoluções vigentes [R$]"
+      - name: receita_total_aferida
+        description: "Receita total aferida (receita tarifária + subsidio pago) [R$]"
+      - name: receita_tarifaria_aferida
+        description: "Receita tarifária aferida com base no RDO informado pelos consórcios [R$]"
+      - name: subsidio_pago
+        description: "Subsídio pago [R$]"
+      - name: saldo
+        description: "Saldo entre a receita esperada e aferida, descontado o subsídio glosado [R$]"
   - name: balanco_servico_quinzena
     description: "Balanço da receita aferida e esperada por serviço e
     quinzena para serviços-dia subsidiados. Ver metodologia em NOTA TÉCNICA TR/SUBTT Nº 01/2024"
@@ -118,8 +148,12 @@ models:
         description: "Data inicial da quinzena"
       - name: data_final_quinzena
         description: "Data final da quinzena"
+      - name: consorcio
+        description: "Consórcio"
       - name: servico
         description: "Serviço"
+      - name: quantidade_dias_subsidiado
+        description: "Quantidade de dias subsidiado"
       - name: km_subsidiada
         description: "Quilometragem apurada e subsidiada via algoritmo [km]"
       - name: receita_total_esperada

--- a/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
@@ -2,6 +2,8 @@
   Etapa de tratamento com base na resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027 (Processo MTR-PRO-2024/06270)
 */
 
+{% if var("encontro_contas_modo") == "pos_gt" %}
+{{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
 SELECT
     quinzena,
     PARSE_DATE("%m/%d/%Y", data_inicio_quinzena) AS data_inicio_quinzena,
@@ -23,3 +25,6 @@ SELECT
     AS servico_corrigido_rioonibus,
 FROM
     {{ source("projeto_subsidio_sppo_encontro_contas", "rdo_correcao_rioonibus_servico_quinzena") }}
+{% else %}
+{{ config(enabled=false) }}
+{% endif %}

--- a/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
@@ -8,7 +8,7 @@ SELECT
     tipo_servico_rdo,
     ordem_servico_rdo,
     quantidade_dias_rdo,
-    SAFE_CAST(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(receita_tarifaria_aferida_rdo, r"\.", ""), r",", "."), r"[^\d\.-]", "") AS FLOAT64) AS receita_tarifaria_aferida_rdo,
+    SAFE_CAST(REPLACE(REGEXP_REPLACE(receita_tarifaria_aferida_rdo , r"[^\d,-]", ""), ",", ".") AS FLOAT64) AS receita_tarifaria_aferida_rdo,
     justificativa,
     acao,
     CASE

--- a/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
@@ -2,8 +2,8 @@
   Etapa de tratamento com base na resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027 (Processo MTR-PRO-2024/06270)
 */
 
-{% if var("encontro_contas_modo") == "pos_gt" %}
-{{ config(alias=this.name ~ "_" ~ var('encontro_contas_modo')) }}
+{% if var("encontro_contas_modo") == "_pos_gt" %}
+{{ config(alias=this.name ~ var('encontro_contas_modo')) }}
 SELECT
     quinzena,
     PARSE_DATE("%m/%d/%Y", data_inicio_quinzena) AS data_inicio_quinzena,

--- a/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
@@ -1,5 +1,5 @@
 /*
-  Etapa de tratamento com base na resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027
+  Etapa de tratamento com base na resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027 (Processo MTR-PRO-2024/06270)
 */
 
 SELECT

--- a/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
@@ -1,5 +1,5 @@
 /*
-  Etapa de tratamento com base na resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027 (Processo MTR-PRO-2024/06270)
+  Etapa de tratamento com base na resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027 (Processo.Rio MTR-PRO-2024/06270)
 */
 
 {% if var("encontro_contas_modo") == "_pos_gt" %}

--- a/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
@@ -1,3 +1,7 @@
+/*
+  Etapa de tratamento com base na resposta aos ofícios MTR-OFI-2024/03024, MTR-OFI-2024/03025, MTR-OFI-2024/03026 e MTR-OFI-2024/03027
+*/
+
 SELECT
     quinzena,
     PARSE_DATE("%m/%d/%Y", data_inicio_quinzena) AS data_inicio_quinzena,

--- a/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
@@ -1,0 +1,21 @@
+SELECT
+    quinzena,
+    PARSE_DATE("%m/%d/%Y", data_inicio_quinzena) AS data_inicio_quinzena,
+    PARSE_DATE("%m/%d/%Y", data_final_quinzena) AS data_final_quinzena,
+    consorcio_rdo,
+    IF(LENGTH(servico_tratado_rdo) < 3, LPAD(servico_tratado_rdo, 3, "0"), servico_tratado_rdo) AS servico_tratado_rdo,
+    IF(LENGTH(linha_rdo) < 3, LPAD(linha_rdo, 3, "0"), linha_rdo) AS linha_rdo,
+    tipo_servico_rdo,
+    ordem_servico_rdo,
+    quantidade_dias_rdo,
+    SAFE_CAST(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(receita_tarifaria_aferida_rdo, r"\.", ""), r",", "."), r"[^\d\.-]", "") AS FLOAT64) AS receita_tarifaria_aferida_rdo,
+    justificativa,
+    acao,
+    CASE
+      WHEN justificativa = "SVA665 a partir de 06/2022, SVB665 a partir de 08/2022" AND acao = "Considerar como SVB no período indicado" THEN "SVB665"
+    ELSE
+    REGEXP_EXTRACT(acao, "(?:[A-Z]+|)[0-9]+")
+  END
+    AS servico_corrigido_rioonibus,
+FROM
+    {{ source("projeto_subsidio_sppo_encontro_contas", "rdo_correcao_rioonibus_servico_quinzena")}}

--- a/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
+++ b/models/projeto_subsidio_sppo_encontro_contas/staging/rdo_correcao_rioonibus_servico_quinzena.sql
@@ -18,4 +18,4 @@ SELECT
   END
     AS servico_corrigido_rioonibus,
 FROM
-    {{ source("projeto_subsidio_sppo_encontro_contas", "rdo_correcao_rioonibus_servico_quinzena")}}
+    {{ source("projeto_subsidio_sppo_encontro_contas", "rdo_correcao_rioonibus_servico_quinzena") }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -133,3 +133,9 @@ sources:
     tables:
       - name: cb
       - name: cett
+      
+  - name: projeto_subsidio_sppo_encontro_contas
+    database: rj-smtr-staging
+
+    tables:
+      - name: rdo_correcao_rioonibus_servico_quinzena


### PR DESCRIPTION
# Changelog - projeto_subsidio_sppo_encontro_contas

## [1.0.3] - 2024-06-07

### Adicionado

- Adiciona modelo `staging.rdo_correcao_rioonibus_servico_quinzena.sql`
- Adiciona modos de execução `""` (antes das alterações do Grupo de Trabalho) e `"_pos_gt"` (após as alterações do Grupo de Trabalho) conforme Processo.Rio MTR-PRO-2024/06270 e as respectivas alterações dos nomes das tabelas
- Adiciona novo tratamento de serviços do RDO no modelo `balanco_servico_dia_pos_gt.sql` com base no modelo `balanco_servico_dia.sql`
- Adiciona e altera descrições no schema.yml dos modelos