### PR TITLE
Ticketing View

### DIFF
--- a/models/mit_ipea_project/CHANGELOG.md
+++ b/models/mit_ipea_project/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog - MIT IPEA Project
+
+## [1.0.0] - 2024-06-21
+
+### Added
+- Create models:
+  - `vw_ticketing.sql` ([#333](https://github.com/prefeitura-rio/queries-rj-smtr/pull/333))
+    -  View containing ticketing data cleaned for:
+        - Card types that do not unique identify users (these include cash transactions)
+        - Pre-identified card ids with extreme values
+  - `h3_gps.sql` (`incremental`) ([#307](https://github.com/prefeitura-rio/queries-rj-smtr/pull/307))
+    - Assigns each GPS ping to a H3 tile using vw_h3. This consolidates multiple GPS pings for a given vehicle into a single h3 tile `tile_entry_time` and `tile_exit_time`.
+  - `vw_h3.sql` ([#307](https://github.com/prefeitura-rio/queries-rj-smtr/pull/307))
+    - Utility view which converts geometry column from STRING to GEOGRAPHY type and adds `centriod` column.
+  - `vw_vehicle_details.sql` ([#307](https://github.com/prefeitura-rio/queries-rj-smtr/pull/307))
+    - Utility view. Takes `rj-smtr.veiculo.sppo_licenciamento` and aliases column names to english.

--- a/models/mit_ipea_project/vw_ticketing.sql
+++ b/models/mit_ipea_project/vw_ticketing.sql
@@ -13,7 +13,8 @@ WITH raw_ticketing AS (SELECT data                                              
                        FROM `rj-smtr.br_rj_riodejaneiro_onibus_tg.transacao`
                        WHERE tipo_cartao NOT IN (SELECT chave
                                                  FROM `rj-smtr.br_rj_riodejaneiro_onibus_tg.dicionario`
-                                                 -- Card types to drop:
+                                                -- Card types to drop:
+                                                --  These card types do not uniquely identify users. These include cash transactions.
                                                  WHERE VALOR IN (
                                                                  'RIOONIBUS - BOTOEIRA',
                                                                  'RIOONIBUS - ROD. CIDADAO RIO ONIBUS',

--- a/models/mit_ipea_project/vw_ticketing.sql
+++ b/models/mit_ipea_project/vw_ticketing.sql
@@ -34,7 +34,7 @@ SELECT *,
            AS daily_trip_stage
 
 FROM raw_ticketing
-# These card_ids have an average of >400 transactions per day
+-- These card_ids have an average of >400 transactions per day
 WHERE card_id NOT IN ('2e6e15a38c6fe8b624fca13be00a737947a8096fd5620795696b5b63cd7feea4',
                '9af15b336e6a9619928537df30b2e6a2376569fcf9d7e773eccede65606529a0')
 

--- a/models/mit_ipea_project/vw_ticketing.sql
+++ b/models/mit_ipea_project/vw_ticketing.sql
@@ -1,0 +1,41 @@
+-- ticketing view, ticketing data cleaned for:
+-- - card types that do not unique identify users (these include cash transactions)
+-- - pre-identified card ids with extreme values
+CREATE OR REPLACE VIEW `rj-smtr-dev.mit_ipea_project.vw_ticketing` AS
+
+WITH raw_ticketing AS (SELECT data                                                               AS as_at,
+                              EXTRACT(time from datetime)                                        AS origin_time,
+                              id_cartao                                                          AS card_id,
+                              tipo_cartao                                                        AS card_type,
+                              ROW_NUMBER() OVER (PARTITION BY id_cartao, data ORDER BY datetime) AS daily_trip_id,
+                              id_empresa                                                         AS company_id,
+                              id_veiculo                                                         AS vehicle_id
+
+                       FROM `rj-smtr.br_rj_riodejaneiro_onibus_tg.transacao`
+                       WHERE tipo_cartao NOT IN (SELECT chave
+                                                 FROM `rj-smtr.br_rj_riodejaneiro_onibus_tg.dicionario`
+                                                 -- Card types to drop:
+                                                 WHERE VALOR IN (
+                                                                 'RIOONIBUS - BOTOEIRA',
+                                                                 'RIOONIBUS - ROD. CIDADAO RIO ONIBUS',
+                                                                 'RIOONIBUS - RODOVIARIO RIO ONIBUS'
+                                                     )))
+
+SELECT *,
+       CASE
+           WHEN MAX(daily_trip_id) OVER (PARTITION BY card_id, as_at) = 1
+               THEN 'Only transaction'
+           WHEN MAX(daily_trip_id) OVER (PARTITION BY card_id, as_at) = daily_trip_id
+               THEN 'Last transaction'
+           WHEN MIN(daily_trip_id) OVER (PARTITION BY card_id, as_at) = daily_trip_id
+               THEN 'First transaction'
+           ELSE
+               'Intermediate transaction'
+           END
+           AS daily_trip_stage
+
+FROM raw_ticketing
+# These card_ids have an average of >400 transactions per day
+WHERE card_id NOT IN ('2e6e15a38c6fe8b624fca13be00a737947a8096fd5620795696b5b63cd7feea4',
+               '9af15b336e6a9619928537df30b2e6a2376569fcf9d7e773eccede65606529a0')
+

--- a/models/mit_ipea_project/vw_ticketing.sql
+++ b/models/mit_ipea_project/vw_ticketing.sql
@@ -1,7 +1,6 @@
 -- ticketing view, ticketing data cleaned for:
 -- - card types that do not unique identify users (these include cash transactions)
 -- - pre-identified card ids with extreme values
-CREATE OR REPLACE VIEW `rj-smtr-dev.mit_ipea_project.vw_ticketing` AS
 
 WITH raw_ticketing AS (SELECT data                                                               AS as_at,
                               EXTRACT(time from datetime)                                        AS origin_time,


### PR DESCRIPTION
`vw_ticketing`: ticketing view containing ticketing data cleaned for:
- card types that do not unique identify users (these include cash transactions)
- pre-identified card ids with extreme values

Tested with DBT `run.py`.

# Changelog - MIT IPEA Project

## [1.0.0] - 2024-06-21

### Added
- Create models:
  - `vw_ticketing.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/333)
    -  View containing ticketing data cleaned for:
        - Card types that do not unique identify users (these include cash transactions)
        - Pre-identified card ids with extreme values
  - `h3_gps.sql` (`incremental`) (https://github.com/prefeitura-rio/queries-rj-smtr/pull/307)
    - Assigns each GPS ping to a H3 tile using vw_h3. This consolidates multiple GPS pings for a given vehicle into a single h3 tile `tile_entry_time` and `tile_exit_time`.
  - `vw_h3.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/307)
    - Utility view which converts geometry column from STRING to GEOGRAPHY type and adds `centriod` column.
  - `vw_vehicle_details.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/307)
    - Utility view. Takes `rj-smtr.veiculo.sppo_licenciamento` and aliases column names to english.