### PR TITLE
Altera tratamento nos modelos `viagens_remuneradas.sql` + `subsidio_data_versao_efetiva.sql`

### DIFF
--- a/models/dashboard_subsidio_sppo/CHANGELOG.md
+++ b/models/dashboard_subsidio_sppo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Altera critérios para o `indicador_viagem_remunerada` no modelo `viagens_remuneradas.sql`, de forma a ser indicado como nulo em caso de falha na união de tabelas ()
+- Altera critérios para o `indicador_viagem_remunerada` no modelo `viagens_remuneradas.sql`, de forma a ser indicado como nulo em caso de falha na união de tabelas (https://github.com/prefeitura-rio/queries-rj-smtr/pull/337)
 
 ## [7.1.0] - 2024-06-06
 

--- a/models/dashboard_subsidio_sppo/CHANGELOG.md
+++ b/models/dashboard_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - dashboard_subsidio_sppo
 
+## [7.1.1] - 2024-06-12
+
+### Alterado
+
+- Altera critérios para o `indicador_viagem_remunerada` no modelo `viagens_remuneradas.sql`, de forma a ser indicado como nulo em caso de falha na união de tabelas ()
+
 ## [7.1.0] - 2024-06-06
 
 ### Alterado

--- a/models/dashboard_subsidio_sppo/viagens_remuneradas.sql
+++ b/models/dashboard_subsidio_sppo/viagens_remuneradas.sql
@@ -25,6 +25,7 @@ WITH
     distancia_total_planejada AS km_planejada,
   FROM
     {{ ref("viagem_planejada") }}
+    -- rj-smtr.projeto_subsidio_sppo.viagem_planejada
   WHERE
     data BETWEEN DATE("{{ var("start_date") }}")
     AND DATE( "{{ var("end_date") }}" )
@@ -44,6 +45,7 @@ WITH
     tipo_os,
   FROM
       {{ ref("ordem_servico_gtfs") }}
+      -- rj-smtr.gtfs.ordem_servico
   WHERE
     feed_start_date IN ('{{ feed_start_dates|join("', '") }}')
   ),
@@ -55,6 +57,7 @@ WITH
     COALESCE(feed_start_date, data_versao_trips, data_versao_shapes, data_versao_frequencies) AS feed_start_date
   FROM
       {{ ref("subsidio_data_versao_efetiva") }}
+      -- rj-smtr.projeto_subsidio_sppo.subsidio_data_versao_efetiva (alterar também query no bloco execute)
   WHERE
     data BETWEEN DATE("{{ var("start_date") }}")
     AND DATE( "{{ var("end_date") }}" )
@@ -89,6 +92,7 @@ WITH
     distancia_planejada
  FROM
     {{ ref("viagem_completa") }}
+    -- rj-smtr.projeto_subsidio_sppo.viagem_completa
   WHERE
     data BETWEEN DATE("{{ var("start_date") }}")
     AND DATE( "{{ var("end_date") }}" ) ),
@@ -100,6 +104,7 @@ WITH
     status
   FROM
     {{ ref("sppo_veiculo_dia") }}
+    -- rj-smtr.veiculo.sppo_veiculo_dia
   WHERE
     data BETWEEN DATE("{{ var("start_date") }}")
     AND DATE("{{ var("end_date") }}") ),
@@ -174,6 +179,15 @@ CASE
         AND perc_km_planejada > 200
         AND rn > viagens_planejadas_ida_volta*2
         THEN FALSE
+    WHEN data >= "2023-09-16"
+        AND (p.tipo_dia = "Dia Útil"
+          AND (viagens_planejadas IS NULL
+            OR perc_km_planejada IS NULL
+            OR rn IS NULL
+            OR viagens_planejadas_ida_volta IS NULL
+          )
+        )
+        THEN NULL
     ELSE
         TRUE
     END AS indicador_viagem_remunerada

--- a/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [7.0.3] - 2024-06-12
+
+### Alterado
+
+- Altera lógica do modelo `subsidio_data_versao_efetiva.sql`, de forma a considerar por regra sempre o mesmo intervalo de datas do modelo `feed_info_gtfs.sql` ()
+
 ## [7.0.2] - 2024-05-29
 
 ### Adicionado

--- a/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Altera lógica do modelo `subsidio_data_versao_efetiva.sql`, de forma a considerar por regra sempre o mesmo intervalo de datas do modelo `feed_info_gtfs.sql` ()
+- Altera lógica do modelo `subsidio_data_versao_efetiva.sql`, de forma a considerar por regra sempre o mesmo intervalo de datas do modelo `feed_info_gtfs.sql` (https://github.com/prefeitura-rio/queries-rj-smtr/pull/337)
 
 ## [7.0.2] - 2024-05-29
 

--- a/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -357,8 +357,8 @@ WITH
       WHEN tipo_os = "Extraordinária - Verão" THEN "Verão"
       WHEN tipo_os LIKE "%Madonna%" THEN "Madonna"
     END AS subtipo_dia,
-    SAFE_CAST(i.feed_version AS STRING) AS feed_version,
-    SAFE_CAST(i.feed_start_date AS DATE) AS feed_start_date,
+    i.feed_version,
+    i.feed_start_date,
     tipo_os,
   FROM
     dates AS d

--- a/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -313,11 +313,6 @@ WHERE
 {% endif %}
 
 {% else %}
-{% if execute %}
-  {% set results = run_query("SELECT feed_version, feed_start_date FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date = (SELECT MAX(feed_start_date) FROM " ~ ref('feed_info_gtfs') ~ " WHERE feed_start_date >= DATE_TRUNC(DATE_SUB(DATE('" ~ var("run_date") ~ "'), INTERVAL 30 DAY), MONTH))") %}
-  {% set max_feed_version = results.columns[0].values()[0] %}
-  {% set max_feed_start_date = results.columns[1].values()[0] %}
-{% endif %}
 
 WITH
   dates AS (
@@ -347,39 +342,54 @@ WITH
       WHEN data BETWEEN DATE(2024,03,30) AND DATE(2024,04,14) THEN "2024-03-30"  -- OS abr/Q1
       WHEN data BETWEEN DATE(2024,04,15) AND DATE(2024,05,02) THEN "2024-04-15"  -- OS abr/Q2
       WHEN data BETWEEN DATE(2024,05,03) AND DATE(2024,05,14) THEN "2024-05-03"  -- OS maio/Q1
-      WHEN data BETWEEN DATE(2024,05,15) AND DATE(2024,05,31) THEN "2024-05-15"  -- OS maio/Q2
     END AS feed_version,
     CASE
       WHEN data = DATE(2024,05,04) THEN "Madonna 2024-05-04"
       WHEN data = DATE(2024,05,05) THEN "Madonna 2024-05-05"
       ELSE "Regular"
     END AS tipo_os,
-  FROM UNNEST(GENERATE_DATE_ARRAY("{{var('DATA_SUBSIDIO_V6_INICIO')}}", "2024-12-31")) AS data)
+  FROM UNNEST(GENERATE_DATE_ARRAY("{{var('DATA_SUBSIDIO_V6_INICIO')}}", "2024-12-31")) AS data),
+  data_versao_efetiva_manual AS (
+  SELECT
+    data,
+    tipo_dia,
+    CASE
+      WHEN tipo_os = "Extraordinária - Verão" THEN "Verão"
+      WHEN tipo_os LIKE "%Madonna%" THEN "Madonna"
+    END AS subtipo_dia,
+    SAFE_CAST(i.feed_version AS STRING) AS feed_version,
+    SAFE_CAST(i.feed_start_date AS DATE) AS feed_start_date,
+    tipo_os,
+  FROM
+    dates AS d
+  LEFT JOIN
+    {{ ref('feed_info_gtfs') }} AS i
+  USING
+    (feed_version)
+  WHERE
+  {% if is_incremental() %}
+    data = DATE_SUB(DATE("{{ var("run_date") }}"), INTERVAL 1 DAY)
+  {% else %}
+    data <= DATE_SUB(DATE("{{ var("run_date") }}"), INTERVAL 1 DAY)
+  {% endif %}
+)
 SELECT
   data,
   tipo_dia,
-  CASE
-    WHEN tipo_os = "Extraordinária - Verão" THEN "Verão"
-    WHEN tipo_os LIKE "%Madonna%" THEN "Madonna"
-  END AS subtipo_dia,
+  subtipo_dia,
   SAFE_CAST(NULL AS DATE) AS data_versao_trips,
   SAFE_CAST(NULL AS DATE) AS data_versao_shapes,
   SAFE_CAST(NULL AS DATE) AS data_versao_frequencies,
   SAFE_CAST(NULL AS FLOAT64) AS valor_subsidio_por_km,
-  COALESCE(i.feed_version, "{{ max_feed_version }}") AS feed_version,
-  COALESCE(i.feed_start_date, DATE("{{ max_feed_start_date }}")) AS feed_start_date,
+  COALESCE(d.feed_version, i.feed_version) AS feed_version,
+  COALESCE(d.feed_start_date, i.feed_start_date) AS feed_start_date,
   tipo_os,
 FROM
-  dates AS d
+  data_versao_efetiva_manual AS d
 LEFT JOIN
   {{ ref('feed_info_gtfs') }} AS i
-USING
-  (feed_version)
-WHERE
-{% if is_incremental() %}
-  data = DATE_SUB(DATE("{{ var("run_date") }}"), INTERVAL 1 DAY)
-{% else %}
-  data <= DATE_SUB(DATE("{{ var("run_date") }}"), INTERVAL 1 DAY)
-{% endif %}
+ON
+  (data BETWEEN i.feed_start_date AND i.feed_end_date
+  OR (data >= i.feed_start_date AND i.feed_end_date IS NULL))
 
 {% endif %}


### PR DESCRIPTION
# Changelog - dashboard_subsidio_sppo

## [7.1.1] - 2024-06-12

### Alterado

- Altera critérios para o `indicador_viagem_remunerada` no modelo `viagens_remuneradas.sql`, de forma a ser indicado como nulo em caso de falha na união de tabelas


# Changelog - projeto_subsidio_sppo

## [7.0.3] - 2024-06-12

### Alterado

- Altera lógica do modelo `subsidio_data_versao_efetiva.sql`, de forma a considerar por regra sempre o mesmo intervalo de datas do modelo `feed_info_gtfs.sql`